### PR TITLE
Fix up branding files missing for gtk3 widget toolkit.

### DIFF
--- a/browser/branding/aurora/Makefile.in
+++ b/browser/branding/aurora/Makefile.in
@@ -38,7 +38,7 @@ BRANDING_FILES := \
 	$(NULL)
 endif
 
-ifeq ($(MOZ_WIDGET_TOOLKIT),gtk2)
+ifdef MOZ_WIDGET_GTK
 BRANDING_FILES := \
 	default16.png \
 	default32.png \

--- a/browser/branding/official/Makefile.in
+++ b/browser/branding/official/Makefile.in
@@ -38,7 +38,7 @@ BRANDING_FILES := \
 	$(NULL)
 endif
 
-ifeq ($(MOZ_WIDGET_TOOLKIT),gtk2)
+ifdef MOZ_WIDGET_GTK
 BRANDING_FILES := \
 	default16.png \
 	default32.png \


### PR DESCRIPTION
The branding files are missing when widget toolkit is gtk3.
