### PR TITLE
Fix up multiple definition symbols in skia on none opts platform.

### DIFF
--- a/gfx/skia/moz.build
+++ b/gfx/skia/moz.build
@@ -794,7 +794,6 @@ else:
         'trunk/src/opts/SkMorphology_opts_none.cpp',
         'trunk/src/opts/SkUtils_opts_none.cpp',
         'trunk/src/opts/SkXfermode_opts_none.cpp',
-        'trunk/src/ports/SkDiscardableMemory_none.cpp',
         'trunk/src/ports/SkPurgeableMemoryBlock_none.cpp',
     ]
 


### PR DESCRIPTION
On none optimiations platform (e.g. mips), multiple definition symbols error occured.
