### PR TITLE
Bug 975346 - Part 1: General functions for EffectChains

### DIFF
--- a/gfx/layers/composite/CanvasLayerComposite.h
+++ b/gfx/layers/composite/CanvasLayerComposite.h
@@ -52,6 +52,8 @@ public:
 
   virtual void CleanupResources() MOZ_OVERRIDE;
 
+  virtual void GenEffectChain(EffectChain& aEffect, CompositableHost* aHost) MOZ_OVERRIDE;
+
   CompositableHost* GetCompositableHost() MOZ_OVERRIDE;
 
   virtual LayerComposite* AsLayerComposite() MOZ_OVERRIDE { return this; }

--- a/gfx/layers/composite/ColorLayerComposite.cpp
+++ b/gfx/layers/composite/ColorLayerComposite.cpp
@@ -50,5 +50,17 @@ ColorLayerComposite::RenderLayer(const nsIntRect& aClipRect)
                                transform);
 }
 
+void
+ColorLayerComposite::GenEffectChain(EffectChain& aEffect,
+                                    CompositableHost* aHost)
+{
+  aEffect.mLayerRef = this;
+  gfxRGBA color = GetColor();
+  aEffect.mPrimaryEffect = new EffectSolidColor(gfx::Color(color.r,
+                                                           color.g,
+                                                           color.b,
+                                                           color.a));
+}
+
 } /* layers */
 } /* mozilla */

--- a/gfx/layers/composite/ColorLayerComposite.h
+++ b/gfx/layers/composite/ColorLayerComposite.h
@@ -44,6 +44,8 @@ public:
   virtual void RenderLayer(const nsIntRect& aClipRect) MOZ_OVERRIDE;
   virtual void CleanupResources() MOZ_OVERRIDE {};
 
+  virtual void GenEffectChain(EffectChain& aEffect, CompositableHost* aHost) MOZ_OVERRIDE;
+
   CompositableHost* GetCompositableHost() MOZ_OVERRIDE { return nullptr; }
 
   virtual LayerComposite* AsLayerComposite() MOZ_OVERRIDE { return this; }

--- a/gfx/layers/composite/ContentHost.h
+++ b/gfx/layers/composite/ContentHost.h
@@ -102,11 +102,10 @@ public:
 
   virtual void SetPaintWillResample(bool aResample) { mPaintWillResample = aResample; }
 
-  virtual bool Lock() = 0;
-  virtual void Unlock() = 0;
-
   virtual NewTextureSource* GetTextureSource() = 0;
   virtual NewTextureSource* GetTextureSourceOnWhite() = 0;
+
+  virtual TemporaryRef<TexturedEffect> GenEffect(const gfx::Filter& aFilter) MOZ_OVERRIDE;
 
 protected:
   virtual nsIntPoint GetOriginOffset()
@@ -150,7 +149,7 @@ public:
   virtual void UseComponentAlphaTextures(TextureHost* aTextureOnBlack,
                                          TextureHost* aTextureOnWhite) MOZ_OVERRIDE;
 
-  virtual bool Lock() {
+  virtual bool Lock() MOZ_OVERRIDE {
     MOZ_ASSERT(!mLocked);
     if (!mTextureHost) {
       return false;
@@ -166,7 +165,7 @@ public:
     mLocked = true;
     return true;
   }
-  virtual void Unlock() {
+  virtual void Unlock() MOZ_OVERRIDE {
     MOZ_ASSERT(mLocked);
     mTextureHost->Unlock();
     if (mTextureHostOnWhite) {
@@ -175,11 +174,11 @@ public:
     mLocked = false;
   }
 
-  virtual NewTextureSource* GetTextureSource() {
+  virtual NewTextureSource* GetTextureSource() MOZ_OVERRIDE {
     MOZ_ASSERT(mLocked);
     return mTextureHost->GetTextureSources();
   }
-  virtual NewTextureSource* GetTextureSourceOnWhite() {
+  virtual NewTextureSource* GetTextureSourceOnWhite() MOZ_OVERRIDE {
     MOZ_ASSERT(mLocked);
     if (mTextureHostOnWhite) {
       return mTextureHostOnWhite->GetTextureSources();
@@ -281,20 +280,20 @@ public:
 
   virtual void PrintInfo(nsACString& aTo, const char* aPrefix) MOZ_OVERRIDE;
 
-  virtual bool Lock() {
+  virtual bool Lock() MOZ_OVERRIDE {
     MOZ_ASSERT(!mLocked);
     ProcessTextureUpdates();
     mLocked = true;
     return true;
   }
 
-  virtual void Unlock() {
+  virtual void Unlock() MOZ_OVERRIDE {
     MOZ_ASSERT(mLocked);
     mLocked = false;
   }
 
-  virtual NewTextureSource* GetTextureSource();
-  virtual NewTextureSource* GetTextureSourceOnWhite();
+  virtual NewTextureSource* GetTextureSource() MOZ_OVERRIDE;
+  virtual NewTextureSource* GetTextureSourceOnWhite() MOZ_OVERRIDE;
 
 private:
 

--- a/gfx/layers/composite/ImageHost.cpp
+++ b/gfx/layers/composite/ImageHost.cpp
@@ -31,6 +31,7 @@ ImageHost::ImageHost(const TextureInfo& aTextureInfo)
   : CompositableHost(aTextureInfo)
   , mFrontBuffer(nullptr)
   , mHasPictureRect(false)
+  , mLocked(false)
 {}
 
 ImageHost::~ImageHost() {}
@@ -81,12 +82,12 @@ ImageHost::Composite(EffectChain& aEffectChain,
   mFrontBuffer->SetCompositor(GetCompositor());
   mFrontBuffer->SetCompositableBackendSpecificData(GetCompositableBackendSpecificData());
 
-  AutoLockTextureHost autoLock(mFrontBuffer);
+  AutoLockCompositableHost autoLock(this);
   if (autoLock.Failed()) {
     NS_WARNING("failed to lock front buffer");
     return;
   }
-  RefPtr<NewTextureSource> source = mFrontBuffer->GetTextureSources();
+  RefPtr<NewTextureSource> source = GetTextureSource();
   if (!source) {
     return;
   }
@@ -239,6 +240,48 @@ ImageHost::GetAsSurface()
   return mFrontBuffer->GetAsSurface();
 }
 #endif
+
+bool
+ImageHost::Lock()
+{
+  MOZ_ASSERT(!mLocked);
+  if (!mFrontBuffer->Lock()) {
+    return false;
+  }
+  mLocked = true;
+  return true;
+}
+
+void
+ImageHost::Unlock()
+{
+  MOZ_ASSERT(mLocked);
+  mFrontBuffer->Unlock();
+  mLocked = false;
+}
+
+TemporaryRef<NewTextureSource>
+ImageHost::GetTextureSource()
+{
+  MOZ_ASSERT(mLocked);
+  return mFrontBuffer->GetTextureSources();
+}
+
+TemporaryRef<TexturedEffect>
+ImageHost::GenEffect(const gfx::Filter& aFilter)
+{
+  RefPtr<NewTextureSource> source = GetTextureSource();
+  if (!source) {
+    return nullptr;
+  }
+  RefPtr<TexturedEffect> effect = CreateTexturedEffect(mFrontBuffer->GetFormat(),
+                                                       source,
+                                                       aFilter);
+  if (!effect) {
+    return nullptr;
+  }
+  return effect;
+}
 
 }
 }

--- a/gfx/layers/composite/ImageHost.h
+++ b/gfx/layers/composite/ImageHost.h
@@ -79,11 +79,20 @@ public:
   virtual TemporaryRef<gfx::DataSourceSurface> GetAsSurface() MOZ_OVERRIDE;
 #endif
 
+  virtual bool Lock() MOZ_OVERRIDE;
+
+  virtual void Unlock() MOZ_OVERRIDE;
+
+  virtual TemporaryRef<NewTextureSource> GetTextureSource();
+
+  virtual TemporaryRef<TexturedEffect> GenEffect(const gfx::Filter& aFilter) MOZ_OVERRIDE;
+
 protected:
 
   RefPtr<TextureHost> mFrontBuffer;
   nsIntRect mPictureRect;
   bool mHasPictureRect;
+  bool mLocked;
 };
 
 }

--- a/gfx/layers/composite/ImageLayerComposite.cpp
+++ b/gfx/layers/composite/ImageLayerComposite.cpp
@@ -161,6 +161,17 @@ ImageLayerComposite::CleanupResources()
   mImageHost = nullptr;
 }
 
+void
+ImageLayerComposite::GenEffectChain(EffectChain& aEffect,
+                                    CompositableHost* aHost)
+{
+  // Add layerRef
+  aEffect.mLayerRef = this;
+
+  // Add primary effect, if the buffer in aHost is locked.
+  aEffect.mPrimaryEffect = aHost->GenEffect(gfx::ToFilter(mFilter));
+}
+
 nsACString&
 ImageLayerComposite::PrintInfo(nsACString& aTo, const char* aPrefix)
 {

--- a/gfx/layers/composite/ImageLayerComposite.h
+++ b/gfx/layers/composite/ImageLayerComposite.h
@@ -49,6 +49,8 @@ public:
 
   virtual void CleanupResources() MOZ_OVERRIDE;
 
+  virtual void GenEffectChain(EffectChain& aEffect, CompositableHost* aHost) MOZ_OVERRIDE;
+
   CompositableHost* GetCompositableHost() MOZ_OVERRIDE;
 
   virtual LayerComposite* AsLayerComposite() MOZ_OVERRIDE { return this; }

--- a/gfx/layers/composite/LayerManagerComposite.h
+++ b/gfx/layers/composite/LayerManagerComposite.h
@@ -74,7 +74,7 @@ class LayerManagerComposite : public LayerManager
 public:
   LayerManagerComposite(Compositor* aCompositor);
   ~LayerManagerComposite();
-  
+
   virtual void Destroy() MOZ_OVERRIDE;
 
   /**
@@ -267,7 +267,7 @@ private:
   RefPtr<Compositor> mCompositor;
   nsAutoPtr<LayerProperties> mClonedLayerTreeProperties;
 
-  /** 
+  /**
    * Context target, nullptr when drawing directly to our swap chain.
    */
   RefPtr<gfx::DrawTarget> mTarget;
@@ -340,6 +340,8 @@ public:
   virtual void DestroyFrontBuffer() { }
 
   void AddBlendModeEffect(EffectChain& aEffectChain);
+
+  virtual void GenEffectChain(EffectChain& aEffect, CompositableHost* aHost) { }
 
   /**
    * The following methods are

--- a/gfx/layers/composite/ThebesLayerComposite.cpp
+++ b/gfx/layers/composite/ThebesLayerComposite.cpp
@@ -193,6 +193,17 @@ ThebesLayerComposite::GetEffectiveResolution()
   return CSSToScreenScale(1.0);
 }
 
+void
+ThebesLayerComposite::GenEffectChain(EffectChain& aEffect,
+                                     CompositableHost* aHost)
+{
+  // Add layerRef
+  aEffect.mLayerRef = this;
+
+  // Add primary effect, should be locked first
+  aEffect.mPrimaryEffect = aHost->GenEffect(gfx::Filter::LINEAR);
+}
+
 nsACString&
 ThebesLayerComposite::PrintInfo(nsACString& aTo, const char* aPrefix)
 {

--- a/gfx/layers/composite/ThebesLayerComposite.h
+++ b/gfx/layers/composite/ThebesLayerComposite.h
@@ -56,6 +56,8 @@ public:
 
   virtual void CleanupResources() MOZ_OVERRIDE;
 
+  virtual void GenEffectChain(EffectChain& aEffect, CompositableHost* aHost) MOZ_OVERRIDE;
+
   virtual bool SetCompositableHost(CompositableHost* aHost) MOZ_OVERRIDE;
 
   virtual LayerComposite* AsLayerComposite() MOZ_OVERRIDE { return this; }

--- a/gfx/layers/composite/TiledContentHost.cpp
+++ b/gfx/layers/composite/TiledContentHost.cpp
@@ -513,6 +513,11 @@ TiledContentHost::Dump(FILE* aFile,
   }
 }
 #endif
+TemporaryRef<TexturedEffect>
+TiledContentHost::GenEffect(const gfx::Filter& aFilter)
+{
+  return nullptr;
+}
 
 } // namespace
 } // namespace

--- a/gfx/layers/composite/TiledContentHost.h
+++ b/gfx/layers/composite/TiledContentHost.h
@@ -246,7 +246,7 @@ public:
     mLowPrecisionTiledBuffer.SetReleaseFence(aReleaseFence);
   }
 #endif
-
+  virtual TemporaryRef<TexturedEffect> GenEffect(const gfx::Filter& aFilter) MOZ_OVERRIDE;
 private:
 
   void RenderLayerBuffer(TiledLayerBufferComposite& aLayerBuffer,


### PR DESCRIPTION
1. Support GenEffectChain() for LayerComposite.
2. Support GenEffect() for CompositableHost.
3. Move AutoLock to compositeHost.
