### PR TITLE
Bug 975346 - Part 1: General functions for Effects

### DIFF
--- a/gfx/layers/composite/CanvasLayerComposite.cpp
+++ b/gfx/layers/composite/CanvasLayerComposite.cpp
@@ -87,18 +87,6 @@ CanvasLayerComposite::RenderLayer(const nsIntRect& aClipRect)
   }
 #endif
 
-  GraphicsFilter filter = mFilter;
-#ifdef ANDROID
-  // Bug 691354
-  // Using the LINEAR filter we get unexplained artifacts.
-  // Use NEAREST when no scaling is required.
-  Matrix matrix;
-  bool is2D = GetEffectiveTransform().Is2D(&matrix);
-  if (is2D && !ThebesMatrix(matrix).HasNonTranslationOrFlip()) {
-    filter = GraphicsFilter::FILTER_NEAREST;
-  }
-#endif
-
   EffectChain effectChain(this);
   AddBlendModeEffect(effectChain);
 
@@ -108,7 +96,7 @@ CanvasLayerComposite::RenderLayer(const nsIntRect& aClipRect)
   mImageHost->Composite(effectChain,
                         GetEffectiveOpacity(),
                         GetEffectiveTransform(),
-                        gfx::ToFilter(filter),
+                        GetEffectFilter(),
                         clipRect);
   mImageHost->BumpFlashCounter();
 }
@@ -130,6 +118,23 @@ CanvasLayerComposite::CleanupResources()
     mImageHost->Detach(this);
   }
   mImageHost = nullptr;
+}
+
+gfx::Filter
+CanvasLayerComposite::GetEffectFilter()
+{
+  GraphicsFilter filter = mFilter;
+#ifdef ANDROID
+  // Bug 691354
+  // Using the LINEAR filter we get unexplained artifacts.
+  // Use NEAREST when no scaling is required.
+  Matrix matrix;
+  bool is2D = GetEffectiveTransform().Is2D(&matrix);
+  if (is2D && !ThebesMatrix(matrix).HasNonTranslationOrFlip()) {
+    filter = GraphicsFilter::FILTER_NEAREST;
+  }
+#endif
+  return gfx::ToFilter(filter);
 }
 
 nsACString&

--- a/gfx/layers/composite/CanvasLayerComposite.h
+++ b/gfx/layers/composite/CanvasLayerComposite.h
@@ -52,6 +52,8 @@ public:
 
   virtual void CleanupResources() MOZ_OVERRIDE;
 
+  virtual gfx::Filter GetEffectFilter() MOZ_OVERRIDE;
+
   CompositableHost* GetCompositableHost() MOZ_OVERRIDE;
 
   virtual LayerComposite* AsLayerComposite() MOZ_OVERRIDE { return this; }

--- a/gfx/layers/composite/ContentHost.h
+++ b/gfx/layers/composite/ContentHost.h
@@ -102,11 +102,10 @@ public:
 
   virtual void SetPaintWillResample(bool aResample) { mPaintWillResample = aResample; }
 
-  virtual bool Lock() = 0;
-  virtual void Unlock() = 0;
-
   virtual NewTextureSource* GetTextureSource() = 0;
   virtual NewTextureSource* GetTextureSourceOnWhite() = 0;
+
+  virtual TemporaryRef<TexturedEffect> GenEffect(const gfx::Filter& aFilter) MOZ_OVERRIDE;
 
 protected:
   virtual nsIntPoint GetOriginOffset()
@@ -150,7 +149,7 @@ public:
   virtual void UseComponentAlphaTextures(TextureHost* aTextureOnBlack,
                                          TextureHost* aTextureOnWhite) MOZ_OVERRIDE;
 
-  virtual bool Lock() {
+  virtual bool Lock() MOZ_OVERRIDE {
     MOZ_ASSERT(!mLocked);
     if (!mTextureHost) {
       return false;
@@ -166,7 +165,7 @@ public:
     mLocked = true;
     return true;
   }
-  virtual void Unlock() {
+  virtual void Unlock() MOZ_OVERRIDE {
     MOZ_ASSERT(mLocked);
     mTextureHost->Unlock();
     if (mTextureHostOnWhite) {
@@ -175,11 +174,11 @@ public:
     mLocked = false;
   }
 
-  virtual NewTextureSource* GetTextureSource() {
+  virtual NewTextureSource* GetTextureSource() MOZ_OVERRIDE {
     MOZ_ASSERT(mLocked);
     return mTextureHost->GetTextureSources();
   }
-  virtual NewTextureSource* GetTextureSourceOnWhite() {
+  virtual NewTextureSource* GetTextureSourceOnWhite() MOZ_OVERRIDE {
     MOZ_ASSERT(mLocked);
     if (mTextureHostOnWhite) {
       return mTextureHostOnWhite->GetTextureSources();
@@ -281,20 +280,20 @@ public:
 
   virtual void PrintInfo(nsACString& aTo, const char* aPrefix) MOZ_OVERRIDE;
 
-  virtual bool Lock() {
+  virtual bool Lock() MOZ_OVERRIDE {
     MOZ_ASSERT(!mLocked);
     ProcessTextureUpdates();
     mLocked = true;
     return true;
   }
 
-  virtual void Unlock() {
+  virtual void Unlock() MOZ_OVERRIDE {
     MOZ_ASSERT(mLocked);
     mLocked = false;
   }
 
-  virtual NewTextureSource* GetTextureSource();
-  virtual NewTextureSource* GetTextureSourceOnWhite();
+  virtual NewTextureSource* GetTextureSource() MOZ_OVERRIDE;
+  virtual NewTextureSource* GetTextureSourceOnWhite() MOZ_OVERRIDE;
 
 private:
 

--- a/gfx/layers/composite/ImageHost.h
+++ b/gfx/layers/composite/ImageHost.h
@@ -79,11 +79,20 @@ public:
   virtual TemporaryRef<gfx::DataSourceSurface> GetAsSurface() MOZ_OVERRIDE;
 #endif
 
+  virtual bool Lock() MOZ_OVERRIDE;
+
+  virtual void Unlock() MOZ_OVERRIDE;
+
+  virtual TemporaryRef<NewTextureSource> GetTextureSource();
+
+  virtual TemporaryRef<TexturedEffect> GenEffect(const gfx::Filter& aFilter) MOZ_OVERRIDE;
+
 protected:
 
   RefPtr<TextureHost> mFrontBuffer;
   nsIntRect mPictureRect;
   bool mHasPictureRect;
+  bool mLocked;
 };
 
 }

--- a/gfx/layers/composite/ImageLayerComposite.cpp
+++ b/gfx/layers/composite/ImageLayerComposite.cpp
@@ -107,7 +107,7 @@ ImageLayerComposite::RenderLayer(const nsIntRect& aClipRect)
   mImageHost->Composite(effectChain,
                         GetEffectiveOpacity(),
                         GetEffectiveTransform(),
-                        gfx::ToFilter(mFilter),
+                        GetEffectFilter(),
                         clipRect);
   mImageHost->BumpFlashCounter();
 }
@@ -159,6 +159,12 @@ ImageLayerComposite::CleanupResources()
     mImageHost->Detach(this);
   }
   mImageHost = nullptr;
+}
+
+gfx::Filter
+ImageLayerComposite::GetEffectFilter()
+{
+  return gfx::ToFilter(mFilter);
 }
 
 nsACString&

--- a/gfx/layers/composite/ImageLayerComposite.h
+++ b/gfx/layers/composite/ImageLayerComposite.h
@@ -49,6 +49,8 @@ public:
 
   virtual void CleanupResources() MOZ_OVERRIDE;
 
+  virtual gfx::Filter GetEffectFilter() MOZ_OVERRIDE;
+
   CompositableHost* GetCompositableHost() MOZ_OVERRIDE;
 
   virtual LayerComposite* AsLayerComposite() MOZ_OVERRIDE { return this; }

--- a/gfx/layers/composite/LayerManagerComposite.h
+++ b/gfx/layers/composite/LayerManagerComposite.h
@@ -74,7 +74,7 @@ class LayerManagerComposite : public LayerManager
 public:
   LayerManagerComposite(Compositor* aCompositor);
   ~LayerManagerComposite();
-  
+
   virtual void Destroy() MOZ_OVERRIDE;
 
   /**
@@ -267,7 +267,7 @@ private:
   RefPtr<Compositor> mCompositor;
   nsAutoPtr<LayerProperties> mClonedLayerTreeProperties;
 
-  /** 
+  /**
    * Context target, nullptr when drawing directly to our swap chain.
    */
   RefPtr<gfx::DrawTarget> mTarget;
@@ -340,6 +340,8 @@ public:
   virtual void DestroyFrontBuffer() { }
 
   void AddBlendModeEffect(EffectChain& aEffectChain);
+
+  virtual gfx::Filter GetEffectFilter() { return gfx::Filter::LINEAR; }
 
   /**
    * The following methods are

--- a/gfx/layers/composite/ThebesLayerComposite.cpp
+++ b/gfx/layers/composite/ThebesLayerComposite.cpp
@@ -147,7 +147,7 @@ ThebesLayerComposite::RenderLayer(const nsIntRect& aClipRect)
   mBuffer->Composite(effectChain,
                      GetEffectiveOpacity(),
                      GetEffectiveTransform(),
-                     gfx::Filter::LINEAR,
+                     GetEffectFilter(),
                      clipRect,
                      &visibleRegion,
                      mRequiresTiledProperties ? &tiledLayerProps


### PR DESCRIPTION
1. Support GenEffectFilter() for LayerComposite.
2. Support GenEffect() for CompositableHost.
3. Move AutoLock to compositeHost.
