### PR TITLE
Release memory on exit (leak detected by cppcheck)

### DIFF
--- a/b2g/gaia/run-b2g.c
+++ b/b2g/gaia/run-b2g.c
@@ -30,6 +30,7 @@ int main(int argc, char* argv[], char* envp[]){
     full_profile_path = (char*) malloc(strlen(cwd) + strlen(GAIA_PATH) + 2);
     if (!full_profile_path) {
         error(NOMEM);
+        free(full_path);
         return -2;
     }
     sprintf(full_path, "%s/%s", cwd, B2G_NAME);


### PR DESCRIPTION
Free memory on exit to avoid leaking.

I've launched cppcheck on mozilla-central. It's still running, but I have some results.
