### PR TITLE
Bug 1164195

### DIFF
--- a/toolkit/devtools/webconsole/utils.js
+++ b/toolkit/devtools/webconsole/utils.js
@@ -1664,25 +1664,19 @@ WebConsoleCommands._registerOriginal("$_", {
  * @return array of nsIDOMNode
  */
 WebConsoleCommands._registerOriginal("$x", function JSTH_$x(aOwner, aXPath,
-aContext), r_node.UNORDERED_NODE_ITERATOR_TYPE
+aContext, resultType.UNORDERED_NODE_ITERATOR_TYPE) 
 {
   let nodes = new aOwner.window.wrappedJSObject.Array();
   let doc = aOwner.window.document;
   aContext = aContext || doc;
   
-  try { 
-    if (r_node == undefined) {
+  if (typeof resultType === "undefined") {
       let results = doc.evaluate(aXPath, aContext, null,
                                  Ci.nsIDOMXPathResult.ANY_TYPE, null);
     } else {
       let results = doc.evaluate(aXPath, aContext, null, 
-                                 Ci.nsIDOMXPathResult.UNORDERED_NODE_ITERATOR_TYPE,
-                                 null); 
+                                 Ci.nsIDOMXPathResult.UNORDERED_NODE_ITERATOR_TYPE, null); 
     }
-   }
-   catch(ex) {
-      return results; 
-   }
 
   let node;
   while ((node = results.iterateNext())) {

--- a/toolkit/devtools/webconsole/utils.js
+++ b/toolkit/devtools/webconsole/utils.js
@@ -1625,7 +1625,9 @@ exports.WebConsoleCommands = WebConsoleCommands;
  */
 WebConsoleCommands._registerOriginal("$", function JSTH_$(aOwner, aSelector)
 {
-  return aOwner.window.document.querySelector(aSelector);
+
+  return aOwner.window.document.Array.prototype.slice.call(document.querySelectorAll(aSelector))
+
 });
 
 /**

--- a/toolkit/devtools/webconsole/utils.js
+++ b/toolkit/devtools/webconsole/utils.js
@@ -1663,14 +1663,27 @@ WebConsoleCommands._registerOriginal("$_", {
  *        Context to run the xPath query on. Uses window.document if not set.
  * @return array of nsIDOMNode
  */
-WebConsoleCommands._registerOriginal("$x", function JSTH_$x(aOwner, aXPath, aContext)
+WebConsoleCommands._registerOriginal("$x", function JSTH_$x(aOwner, aXPath,
+aContext), r_node.UNORDERED_NODE_ITERATOR_TYPE
 {
   let nodes = new aOwner.window.wrappedJSObject.Array();
   let doc = aOwner.window.document;
   aContext = aContext || doc;
+  
+  try { 
+    if (r_node == undefined) {
+      let results = doc.evaluate(aXPath, aContext, null,
+                                 Ci.nsIDOMXPathResult.ANY_TYPE, null);
+    } else {
+      let results = doc.evaluate(aXPath, aContext, null, 
+                                 Ci.nsIDOMXPathResult.UNORDERED_NODE_ITERATOR_TYPE,
+                                 null); 
+    }
+   }
+   catch(ex) {
+      return results; 
+   }
 
-  let results = doc.evaluate(aXPath, aContext, null,
-                             Ci.nsIDOMXPathResult.ANY_TYPE, null);
   let node;
   while ((node = results.iterateNext())) {
     nodes.push(node);


### PR DESCRIPTION
Attempted to fix issue 1 and 2: Changed the input parameters to accept resultType of type UNORDERED_NODE_ITERATOR_TYPE, introduced if-else statement declaring results to be of Ci.nsIDOMXPathResult.UNORDERED_NODE_ITERATOR_TYPE if resultType was defined, else ANY_TYPE. 