### PR TITLE
(BZ: 1055332) Skip bookmark adding when url is "about:blank"

### DIFF
--- a/mobile/android/base/db/LocalBrowserDB.java
+++ b/mobile/android/base/db/LocalBrowserDB.java
@@ -231,6 +231,9 @@ public class LocalBrowserDB implements BrowserDB {
                 final Field urlField = stringsClass.getField(name.replace("_title_", "_url_"));
                 final int urlID = urlField.getInt(null);
                 final String url = context.getString(urlID);
+                if (url.equals("about:blank")) {
+                    continue;
+                }
 
                 final ContentValues bookmarkValue = createBookmark(now, title, url, pos++, folderID);
                 bookmarkValues.add(bookmarkValue);


### PR DESCRIPTION
As described in https://bugzilla.mozilla.org/show_bug.cgi?id=1055332, this patch will not add default bookmarks if the url is "about:blank"