### PR TITLE
Bug 1198604 - [Browser][UAProf]The preset-UAProf will be set to null …

### DIFF
--- a/b2g/chrome/content/settings.js
+++ b/b2g/chrome/content/settings.js
@@ -628,8 +628,7 @@ let settingsToObserve = {
   'ui.touch.radius.bottommm': {
     resetToPref: true
   },
-  'wap.UAProf.tagname': 'x-wap-profile',
-  'wap.UAProf.url': ''
+  'wap.UAProf.tagname': 'x-wap-profile'
 };
 
 for (let key in settingsToObserve) {


### PR DESCRIPTION
…after reboot device

The preset-UAProf will be set to null after reboot device