### PR TITLE
Unify USSD and MMI promise behaviour

### DIFF
--- a/dom/telephony/TelephonyDialCallback.cpp
+++ b/dom/telephony/TelephonyDialCallback.cpp
@@ -21,7 +21,6 @@ TelephonyDialCallback::TelephonyDialCallback(nsPIDOMWindow* aWindow,
                                              Promise* aPromise)
   : TelephonyCallback(aPromise), mWindow(aWindow), mTelephony(aTelephony)
 {
-  MOZ_ASSERT(mTelephony);
 }
 
 nsresult

--- a/dom/telephony/USSDSession.cpp
+++ b/dom/telephony/USSDSession.cpp
@@ -7,7 +7,7 @@
 #include "mozilla/dom/USSDSession.h"
 
 #include "mozilla/dom/USSDSessionBinding.h"
-#include "mozilla/dom/telephony/TelephonyCallback.h"
+#include "mozilla/dom/telephony/TelephonyDialCallback.h"
 #include "nsIGlobalObject.h"
 #include "nsServiceManagerUtils.h"
 
@@ -98,7 +98,7 @@ USSDSession::Send(const nsAString& aUssd, ErrorResult& aRv)
     return nullptr;
   }
 
-  nsCOMPtr<nsITelephonyCallback> callback = new TelephonyCallback(promise);
+  nsCOMPtr<nsITelephonyDialCallback> callback = new TelephonyDialCallback(mWindow, nullptr, promise);
 
   nsresult rv = mService->SendUSSD(mServiceId, aUssd, callback);
   if (NS_FAILED(rv)) {
@@ -116,7 +116,7 @@ USSDSession::Cancel(ErrorResult& aRv)
     return nullptr;
   }
 
-  nsCOMPtr<nsITelephonyCallback> callback = new TelephonyCallback(promise);
+  nsCOMPtr<nsITelephonyDialCallback> callback = new TelephonyDialCallback(mWindow, nullptr, promise);
 
   nsresult rv = mService->CancelUSSD(mServiceId, callback);
   if (NS_FAILED(rv)) {

--- a/dom/telephony/gonk/TelephonyService.js
+++ b/dom/telephony/gonk/TelephonyService.js
@@ -1064,14 +1064,22 @@ TelephonyService.prototype = {
 
       // Handle unknown MMI code as USSD.
       default:
-        this._sendUSSDInternal(aClientId, aMmi.fullMMI, aResponse => {
-          if (aResponse.errorMsg) {
-            aCallback.notifyDialMMIError(aResponse.errorMsg);
-            return;
-          }
-
-          aCallback.notifyDialMMISuccess("");
-        });
+        if (this._ussdSessions[aClientId]) {
+          // Cancel the previous ussd session first.
+          this._cancelUSSDInternal(aClientId, aResponse => {
+            // Fail to cancel ussd session, report error instead of sending ussd
+            // request.
+            if (aResponse.errorMsg) {
+              aCallback.notifyDialMMIError(aResponse.errorMsg);
+              return;
+            }
+            this._sendUSSDInternal(aClientId, aMmi.fullMMI,
+                                   this._defaultMMICallbackHandler.bind(this, aCallback));
+          });
+          return;
+        }
+        this._sendUSSDInternal(aClientId, aMmi.fullMMI,
+                               this._defaultMMICallbackHandler.bind(this, aCallback));
         break;
     }
   },
@@ -1678,6 +1686,14 @@ TelephonyService.prototype = {
     }
   },
 
+  _defaultMMICallbackHandler: function(aCallback, aResponse) {
+    if (aResponse.errorMsg) {
+      aCallback.notifyDialMMIError(aResponse.errorMsg);
+    } else {
+      aCallback.notifyDialMMISuccess("");
+    }
+  },
+
   _getCallsWithState: function(aClientId, aState) {
     let calls = [];
     for (let i in this._currentCalls[aClientId]) {
@@ -2132,24 +2148,9 @@ TelephonyService.prototype = {
   },
 
   _sendUSSDInternal: function(aClientId, aUssd, aCallback) {
-    if (!this._ussdSessions[aClientId]) {
-      this._sendToRilWorker(aClientId, "sendUSSD", { ussd: aUssd }, aResponse => {
-        this._ussdSessions[aClientId] = !aResponse.errorMsg;
-        aCallback(aResponse);
-      });
-      return;
-    }
-
-    // Cancel the previous ussd session first.
-    this._cancelUSSDInternal(aClientId, aResponse => {
-      // Fail to cancel ussd session, report error instead of sending ussd
-      // request.
-      if (aResponse.errorMsg) {
-        aCallback(aResponse);
-        return;
-      }
-
-      this._sendUSSDInternal(aClientId, aUssd, aCallback);
+    this._sendToRilWorker(aClientId, "sendUSSD", { ussd: aUssd }, aResponse => {
+      this._ussdSessions[aClientId] = !aResponse.errorMsg;
+      aCallback(aResponse);
     });
   },
 

--- a/dom/telephony/gonk/TelephonyService.js
+++ b/dom/telephony/gonk/TelephonyService.js
@@ -2143,6 +2143,7 @@ TelephonyService.prototype = {
   },
 
   sendUSSD: function(aClientId, aUssd, aCallback) {
+    aCallback.notifyDialMMI(MMI_KS_SC_USSD);
     this._sendUSSDInternal(aClientId, aUssd,
                            this._defaultCallbackHandler.bind(this, aCallback));
   },
@@ -2155,6 +2156,7 @@ TelephonyService.prototype = {
   },
 
   cancelUSSD: function(aClientId, aCallback) {
+    aCallback.notifyDialMMI(MMI_KS_SC_USSD);
     this._cancelUSSDInternal(aClientId,
                              this._defaultCallbackHandler.bind(this, aCallback));
   },

--- a/dom/telephony/gonk/TelephonyService.js
+++ b/dom/telephony/gonk/TelephonyService.js
@@ -361,6 +361,7 @@ function TelephonyService() {
   this._currentConferenceState = nsITelephonyService.CALL_STATE_UNKNOWN;
   this._audioStates = [];
   this._ussdSessions = [];
+  this._ussdCallbacks = [];
 
   this._cdmaCallWaitingNumber = null;
 
@@ -375,6 +376,7 @@ function TelephonyService() {
   for (let i = 0; i < this._numClients; ++i) {
     this._audioStates[i] = nsITelephonyAudioService.PHONE_STATE_NORMAL;
     this._ussdSessions[i] = false;
+    this._ussdCallbacks[i] = null;
     this._currentCalls[i] = {};
     this._enumerateCallsForClient(i);
   }
@@ -405,6 +407,7 @@ TelephonyService.prototype = {
    *    b) Receiving a session end unsolicited event.
    */
   _ussdSessions: null,
+  _ussdCallbacks: null,
 
   _acquireCallRingWakeLock: function() {
     if (!this._callRingWakeLock) {
@@ -1679,7 +1682,7 @@ TelephonyService.prototype = {
    *        The response from ril_worker.
    */
   _defaultCallbackHandler: function(aCallback, aResponse) {
-    if (aResponse.errorMsg) {
+    if (aResponse && aResponse.errorMsg) {
       aCallback.notifyError(aResponse.errorMsg);
     } else {
       aCallback.notifySuccess();
@@ -1687,10 +1690,10 @@ TelephonyService.prototype = {
   },
 
   _defaultMMICallbackHandler: function(aCallback, aResponse) {
-    if (aResponse.errorMsg) {
+    if (aResponse && aResponse.errorMsg) {
       aCallback.notifyDialMMIError(aResponse.errorMsg);
     } else {
-      aCallback.notifyDialMMISuccess("");
+      aCallback.notifyDialMMISuccess(aResponse);
     }
   },
 
@@ -2149,10 +2152,8 @@ TelephonyService.prototype = {
   },
 
   _sendUSSDInternal: function(aClientId, aUssd, aCallback) {
-    this._sendToRilWorker(aClientId, "sendUSSD", { ussd: aUssd }, aResponse => {
-      this._ussdSessions[aClientId] = !aResponse.errorMsg;
-      aCallback(aResponse);
-    });
+    this._ussdCallbacks[aClientId] = aCallback;
+    this._sendToRilWorker(aClientId, "sendUSSD", { ussd: aUssd }, aResponse => {});
   },
 
   cancelUSSD: function(aClientId, aCallback) {
@@ -2162,10 +2163,8 @@ TelephonyService.prototype = {
   },
 
   _cancelUSSDInternal: function(aClientId, aCallback) {
-    this._sendToRilWorker(aClientId, "cancelUSSD", {}, aResponse => {
-      this._ussdSessions[aClientId] = !!aResponse.errorMsg;
-      aCallback(aResponse);
-    });
+    this._ussdCallbacks[aClientId] = aCallback;
+    this._sendToRilWorker(aClientId, "cancelUSSD", {}, aResponse => {});
   },
 
   get microphoneMuted() {
@@ -2444,7 +2443,14 @@ TelephonyService.prototype = {
       return;
     }
 
-    gTelephonyMessenger.notifyUssdReceived(aClientId, aMessage, aSessionEnded);
+    // If there is a callback registered, call it
+    if (this._ussdCallbacks[aClientId]) {
+      this._ussdCallbacks[aClientId](aMessage);
+      this._ussdCallbacks[aClientId] = null;
+    } else {
+      gTelephonyMessenger.notifyUssdReceived(aClientId, aMessage, aSessionEnded);
+    }
+    
   },
 
   /**

--- a/dom/telephony/gonk/TelephonyService.js
+++ b/dom/telephony/gonk/TelephonyService.js
@@ -1689,11 +1689,15 @@ TelephonyService.prototype = {
     }
   },
 
-  _defaultMMICallbackHandler: function(aCallback, aResponse) {
+  _defaultMMICallbackHandler: function(aCallback, aResponse, aClientId, aSessionEnded) {
     if (aResponse && aResponse.errorMsg) {
       aCallback.notifyDialMMIError(aResponse.errorMsg);
     } else {
-      aCallback.notifyDialMMISuccess(aResponse);
+      if (aSessionEnded) {
+        aCallback.notifyDialMMISuccessWithSession(aResponse, aClientId);
+      } else {
+        aCallback.notifyDialMMISuccess(aResponse);
+      }
     }
   },
 
@@ -2445,7 +2449,7 @@ TelephonyService.prototype = {
 
     // If there is a callback registered, call it
     if (this._ussdCallbacks[aClientId]) {
-      this._ussdCallbacks[aClientId](aMessage);
+      this._ussdCallbacks[aClientId](aMessage, aClientId, aSessionEnded);
       this._ussdCallbacks[aClientId] = null;
     } else {
       gTelephonyMessenger.notifyUssdReceived(aClientId, aMessage, aSessionEnded);

--- a/dom/telephony/gonk/TelephonyService.js
+++ b/dom/telephony/gonk/TelephonyService.js
@@ -1069,18 +1069,21 @@ TelephonyService.prototype = {
       default:
         if (this._ussdSessions[aClientId]) {
           // Cancel the previous ussd session first.
+          debug("USSD-LOG: call for mozTelephony.dial(), but session to cancel first - ussd : " + aMmi.fullMMI);
           this._cancelUSSDInternal(aClientId, aResponse => {
             // Fail to cancel ussd session, report error instead of sending ussd
             // request.
-            if (aResponse.errorMsg) {
+            if (aResponse && aResponse.errorMsg) {
               aCallback.notifyDialMMIError(aResponse.errorMsg);
               return;
             }
+            debug("USSD-LOG: session was cancelled, now sending - ussd : " + aMmi.fullMMI);
             this._sendUSSDInternal(aClientId, aMmi.fullMMI,
                                    this._defaultMMICallbackHandler.bind(this, aCallback));
           });
           return;
         }
+        debug("USSD-LOG: call for mozTelephony.dial(), no session to cancel - ussd : " + aMmi.fullMMI);
         this._sendUSSDInternal(aClientId, aMmi.fullMMI,
                                this._defaultMMICallbackHandler.bind(this, aCallback));
         break;
@@ -1693,7 +1696,7 @@ TelephonyService.prototype = {
     if (aResponse && aResponse.errorMsg) {
       aCallback.notifyDialMMIError(aResponse.errorMsg);
     } else {
-      if (aSessionEnded) {
+      if (!aSessionEnded) {
         aCallback.notifyDialMMISuccessWithSession(aResponse, aClientId);
       } else {
         aCallback.notifyDialMMISuccess(aResponse);
@@ -2150,9 +2153,10 @@ TelephonyService.prototype = {
   },
 
   sendUSSD: function(aClientId, aUssd, aCallback) {
+    debug("USSD-LOG: call for session.send() for USSD : " + aUssd);
     aCallback.notifyDialMMI(MMI_KS_SC_USSD);
     this._sendUSSDInternal(aClientId, aUssd,
-                           this._defaultCallbackHandler.bind(this, aCallback));
+                           this._defaultMMICallbackHandler.bind(this, aCallback));
   },
 
   _sendUSSDInternal: function(aClientId, aUssd, aCallback) {
@@ -2161,9 +2165,10 @@ TelephonyService.prototype = {
   },
 
   cancelUSSD: function(aClientId, aCallback) {
+    debug("USSD-LOG: call for session.cancel()");
     aCallback.notifyDialMMI(MMI_KS_SC_USSD);
     this._cancelUSSDInternal(aClientId,
-                             this._defaultCallbackHandler.bind(this, aCallback));
+                             this._defaultMMICallbackHandler.bind(this, aCallback));
   },
 
   _cancelUSSDInternal: function(aClientId, aCallback) {
@@ -2444,14 +2449,18 @@ TelephonyService.prototype = {
     this._ussdSessions[aClientId] = !aSessionEnded;
 
     if (!oldSession && !this._ussdSessions[aClientId] && !aMessage) {
+      debug("USSD-LOG: received useless message");
       return;
     }
 
     // If there is a callback registered, call it
     if (this._ussdCallbacks[aClientId]) {
-      this._ussdCallbacks[aClientId](aMessage, aClientId, aSessionEnded);
+      debug("USSD-LOG: received important message, using callback");
+      let tempCallback = this._ussdCallbacks[aClientId];
       this._ussdCallbacks[aClientId] = null;
+      tempCallback(aMessage, aClientId, aSessionEnded);
     } else {
+      debug("USSD-LOG: received unsollicited message, using system message");
       gTelephonyMessenger.notifyUssdReceived(aClientId, aMessage, aSessionEnded);
     }
     

--- a/dom/telephony/ipc/TelephonyChild.cpp
+++ b/dom/telephony/ipc/TelephonyChild.cpp
@@ -214,6 +214,9 @@ TelephonyRequestChild::DoResponse(const DialResponseMMISuccess& aResponse)
     case AdditionalInformation::Tvoid_t:
       callback->NotifyDialMMISuccess(statusMessage);
       break;
+    case AdditionalInformation::Tuint32_t:
+      callback->NotifyDialMMISuccessWithSession(statusMessage, info.get_uint32_t());
+      break;
     case AdditionalInformation::Tuint16_t:
       callback->NotifyDialMMISuccessWithInteger(statusMessage, info.get_uint16_t());
       break;

--- a/dom/telephony/ipc/TelephonyIPCService.cpp
+++ b/dom/telephony/ipc/TelephonyIPCService.cpp
@@ -304,7 +304,7 @@ TelephonyIPCService::StopTone(uint32_t aClientId)
 
 NS_IMETHODIMP
 TelephonyIPCService::SendUSSD(uint32_t aClientId, const nsAString& aUssd,
-                              nsITelephonyCallback *aCallback)
+                              nsITelephonyDialCallback *aCallback)
 {
   return SendRequest(nullptr, aCallback,
                      SendUSSDRequest(aClientId, nsString(aUssd)));
@@ -312,7 +312,7 @@ TelephonyIPCService::SendUSSD(uint32_t aClientId, const nsAString& aUssd,
 
 NS_IMETHODIMP
 TelephonyIPCService::CancelUSSD(uint32_t aClientId,
-                                nsITelephonyCallback *aCallback)
+                                nsITelephonyDialCallback *aCallback)
 {
   return SendRequest(nullptr, aCallback, CancelUSSDRequest(aClientId));
 }

--- a/dom/telephony/ipc/TelephonyParent.cpp
+++ b/dom/telephony/ipc/TelephonyParent.cpp
@@ -485,6 +485,14 @@ TelephonyRequestParent::DialCallback::NotifyDialMMISuccess(const nsAString& aSta
 }
 
 NS_IMETHODIMP
+TelephonyRequestParent::DialCallback::NotifyDialMMISuccessWithSession(const nsAString& aStatusMessage,
+                                                                      uint32_t aAdditionalInformation)
+{
+  return SendResponse(DialResponseMMISuccess(nsAutoString(aStatusMessage),
+                                             AdditionalInformation(aAdditionalInformation)));
+}
+
+NS_IMETHODIMP
 TelephonyRequestParent::DialCallback::NotifyDialMMISuccessWithInteger(const nsAString& aStatusMessage,
                                                                       uint16_t aAdditionalInformation)
 {

--- a/dom/telephony/ipc/TelephonyParent.cpp
+++ b/dom/telephony/ipc/TelephonyParent.cpp
@@ -63,13 +63,13 @@ TelephonyParent::RecvPTelephonyRequestConstructor(PTelephonyRequestParent* aActo
 
     case IPCTelephonyRequest::TSendUSSDRequest: {
       const SendUSSDRequest& request = aRequest.get_SendUSSDRequest();
-      service->SendUSSD(request.clientId(), request.ussd(), actor->GetCallback());
+      service->SendUSSD(request.clientId(), request.ussd(), actor->GetDialCallback());
       return true;
     }
 
     case IPCTelephonyRequest::TCancelUSSDRequest: {
       const CancelUSSDRequest& request = aRequest.get_CancelUSSDRequest();
-      service->CancelUSSD(request.clientId(), actor->GetCallback());
+      service->CancelUSSD(request.clientId(), actor->GetDialCallback());
       return true;
     }
 

--- a/dom/telephony/ipc/TelephonyTypes.ipdlh
+++ b/dom/telephony/ipc/TelephonyTypes.ipdlh
@@ -22,6 +22,7 @@ struct IPCCdmaWaitingCallData
 union AdditionalInformation {
   void_t;
   uint16_t;
+  uint32_t;
   nsString[];
   nsMobileCallForwardingOptions[];
 };

--- a/dom/telephony/nsITelephonyService.idl
+++ b/dom/telephony/nsITelephonyService.idl
@@ -135,6 +135,7 @@ interface nsITelephonyDialCallback : nsITelephonyCallback
   void notifyDialMMISuccess(in AString statusMessage);
   void notifyDialMMISuccessWithInteger(in AString statusMessage,
                                        in unsigned short aAdditionalInformation);
+  void notifyDialMMISuccessWithSession(in AString statusMessage, in unsigned long aAdditionalInformation);
   void notifyDialMMISuccessWithStrings(in AString statusMessage,
                                        in unsigned long aLength,
                                        [array, size_is(aLength)] in wstring aAdditionalInformation);

--- a/dom/telephony/nsITelephonyService.idl
+++ b/dom/telephony/nsITelephonyService.idl
@@ -244,7 +244,7 @@ interface nsITelephonyService : nsISupports
    * Otherwise, callback.notifyError() will be called.
    */
   void sendUSSD(in unsigned long clientId, in DOMString ussd,
-                in nsITelephonyCallback callback);
+                in nsITelephonyDialCallback callback);
 
   /**
    * Cancel an existing USSD session.
@@ -252,7 +252,7 @@ interface nsITelephonyService : nsISupports
    * If successful, callback.notifySuccess() will be called.
    * Otherwise, callback.notifyError() will be called.
    */
-  void cancelUSSD(in unsigned long cliendId, in nsITelephonyCallback callback);
+  void cancelUSSD(in unsigned long cliendId, in nsITelephonyDialCallback callback);
 
   attribute bool microphoneMuted;
   attribute bool speakerEnabled;

--- a/dom/webidl/USSDSession.webidl
+++ b/dom/webidl/USSDSession.webidl
@@ -10,8 +10,8 @@
  Constructor(unsigned long serviceId)]
 interface USSDSession {
   [NewObject]
-  Promise<void> send(DOMString ussd);
+  Promise<MMICall> send(DOMString ussd);
 
   [NewObject]
-  Promise<void> cancel();
+  Promise<MMICall> cancel();
 };


### PR DESCRIPTION
Background:
MMI code = any code you enter on your phone with * or #
USSD code = MMI code that doesn't only access the phone's hardware and requires a response from the operator

Here is how you currently send a MMI code from gaia: 
```
      navigator.mozTelephony.dial(MMI_CODE, 0).then(obj => {
        return obj.result.then(function(result) {
          console.log('MMI response: ' + result);
        });
      }).catch(error => console.error(error));
```

It should be possible to do the same thing for a USSD code.
However, currently, the promise is resolved instantly with an empty result if the message is sent correctly, and the real response comes later, in a system message:
```
      navigator.mozSetMessageHandler('ussd-received', e => {
        console.log('USSD response: ' + e.message);
      });
```

Please note that USSD responses can also contain an object called USSDSession, that you can use to cancel or reply to a dialogue with the operator, which usually looks like a menu.

This PR tries to do the following:
- Fix a critical bug that appeared in 2.5, preventing any USSD session from working because they were cancelled everytime: https://bugzilla.mozilla.org/show_bug.cgi?id=1191205
- Silently cancel previous USSD sessions, so that there is no useless "Session expired" message : https://bugzilla.mozilla.org/show_bug.cgi?id=1198676
- Unify USSD and MMI promise behaviour, so that USSDSession methods and mozTelephony.dial() promises for USSD codes are solved once the response is received, along with a USSDSession object if needed. Unsollicited messages should still go in a system message.