### PR TITLE
Fixed Learn more button's boundaries

### DIFF
--- a/devtools/client/netmonitor/src/components/timings-panel.js
+++ b/devtools/client/netmonitor/src/components/timings-panel.js
@@ -63,7 +63,7 @@ function TimingsPanel({ request }) {
   });
 
   return (
-    div({ className: "panel-container" },
+    div({ className: "panel-container, timings-label" },
       timelines,
       MDNLink({
         url: getNetMonitorTimingsURL(),


### PR DESCRIPTION
Bug 1403883 fix, the Learn More link does not exceed the button's boundaries anymore. Div tag was missing a CSS class.