### PR TITLE
added "aboutTelemetry.telemetryProbeDictionary"

### DIFF
--- a/toolkit/content/aboutTelemetry.xhtml
+++ b/toolkit/content/aboutTelemetry.xhtml
@@ -142,6 +142,7 @@
           <li>&aboutTelemetry.firefoxDataDoc;</li>
           <li>&aboutTelemetry.telemetryClientDoc;</li>
           <li>&aboutTelemetry.telemetryDashboard;</li>
+          <li>&aboutTelemetry.telemetryProbeDictionary;</li>
         </ul>
       </section>
 

--- a/toolkit/locales/en-US/chrome/global/aboutTelemetry.dtd
+++ b/toolkit/locales/en-US/chrome/global/aboutTelemetry.dtd
@@ -23,6 +23,7 @@
 <!ENTITY aboutTelemetry.firefoxDataDoc "The <a>Firefox Data Documentation</a> contains guides about how to work with our data tools.">
 <!ENTITY aboutTelemetry.telemetryClientDoc "The <a>Firefox Telemetry client documentation</a> includes definitions for concepts, API documentation and data references.">
 <!ENTITY aboutTelemetry.telemetryDashboard "The <a>Telemetry dashboards</a> allow you to visualize the data Mozilla receives via Telemetry.">
+<!ENTITY aboutTelemetry.telemetryProbeDictionary "The <a>Probe Dictionary</a> helps you to understand what each of the histogram items means, clicking on an item in the Probe Dictionary shows you a description.">
 
 <!ENTITY aboutTelemetry.showInFirefoxJsonViewer "Open in the JSON viewer">
 


### PR DESCRIPTION
I'm not sure though where I should add this link to make it clickable? (this link must be included) https://telemetry.mozilla.org/probe-dictionary/