### PR TITLE
Bug 1518175 - Update bootstrap.py for ElementaryOS

### DIFF
--- a/python/mozboot/mozboot/bootstrap.py
+++ b/python/mozboot/mozboot/bootstrap.py
@@ -181,8 +181,8 @@ DEBIAN_DISTROS = (
     'LinuxMint',
     'Elementary OS',
     'Elementary',
-    '"elementary OS"',
-    '"elementary"'
+    'elementary OS',
+    'elementary'
 )
 
 ADD_GIT_TOOLS_PATH = '''


### PR DESCRIPTION
NotImplementedError: Bootstrap support for this Linux distro not yet available.
>platform.linux_distribution()
>('elementary', '5.0', 'juno')
