### PR TITLE
Fix overflow test wait for condition

### DIFF
--- a/browser/components/customizableui/test/browser_913972_currentset_overflow.js
+++ b/browser/components/customizableui/test/browser_913972_currentset_overflow.js
@@ -18,12 +18,12 @@ add_task(async function() {
   let navbarTarget = CustomizableUI.getCustomizationTarget(navbar);
   let oldChildCount = navbarTarget.childElementCount;
   window.resizeTo(kForceOverflowWidthPx, window.outerHeight);
-  await waitForCondition(() => navbar.hasAttribute("overflowing"));
+  await TestUtils.waitForCondition(() => navbar.hasAttribute("overflowing"));
   ok(navbar.hasAttribute("overflowing"), "Should have an overflowing toolbar.");
   ok(CustomizableUI.inDefaultState, "Should still be in default state when overflowing.");
   ok(navbarTarget.childElementCount < oldChildCount, "Should have fewer children.");
   window.resizeTo(originalWindowWidth, window.outerHeight);
-  await waitForCondition(() => !navbar.hasAttribute("overflowing"));
+  await TestUtils.waitForCondition(() => !navbar.hasAttribute("overflowing"));
   ok(!navbar.hasAttribute("overflowing"), "Should no longer have an overflowing toolbar.");
   ok(CustomizableUI.inDefaultState, "Should still be in default state now we're no longer overflowing.");
 

--- a/doc/1530785.patch
+++ b/doc/1530785.patch
@@ -1,0 +1,25 @@
+# HG changeset patch
+# User Ivan Topolcic <topolcic.ivan@gmail.com>
+# Date 1551920098 18000
+#      Wed Mar 06 19:54:58 2019 -0500
+# Node ID 599aa6e009c66e78e7ce4239a8f3b9487c24a7d7
+# Parent  4bf562c82eca807581df594f7ed2a238c03dae9e
+Changed deprecated waitForCondition calls with TestUtils.waitForCondition
+
+diff --git a/browser/components/customizableui/test/browser_913972_currentset_overflow.js b/browser/components/customizableui/test/browser_913972_currentset_overflow.js
+--- a/browser/components/customizableui/test/browser_913972_currentset_overflow.js
++++ b/browser/components/customizableui/test/browser_913972_currentset_overflow.js
+@@ -18,12 +18,12 @@ add_task(async function() {
+   let navbarTarget = CustomizableUI.getCustomizationTarget(navbar);
+   let oldChildCount = navbarTarget.childElementCount;
+   window.resizeTo(kForceOverflowWidthPx, window.outerHeight);
+-  await waitForCondition(() => navbar.hasAttribute("overflowing"));
++  await TestUtils.waitForCondition(() => navbar.hasAttribute("overflowing"));
+   ok(navbar.hasAttribute("overflowing"), "Should have an overflowing toolbar.");
+   ok(CustomizableUI.inDefaultState, "Should still be in default state when overflowing.");
+   ok(navbarTarget.childElementCount < oldChildCount, "Should have fewer children.");
+   window.resizeTo(originalWindowWidth, window.outerHeight);
+-  await waitForCondition(() => !navbar.hasAttribute("overflowing"));
++  await TestUtils.waitForCondition(() => !navbar.hasAttribute("overflowing"));
+   ok(!navbar.hasAttribute("overflowing"), "Should no longer have an overflowing toolbar.");
+   ok(CustomizableUI.inDefaultState, "Should still be in default state now we're no longer overflowing.");

--- a/doc/a3.md
+++ b/doc/a3.md
@@ -1,0 +1,85 @@
+https://bugzilla.mozilla.org/show_bug.cgi?id=1530785
+
+# Diagnosis
+
+The issue isn't a conventional bug, but a deprecated piece of test code that needs to be updated to be in line with modern FireFox development standards.
+
+The issue, as described by Johann Hofmann, is that the front-end browser test case `browser_913972_currentset_overflow.js` uses deprecated code that is staged to be removed in future versions of FireFox Desktop. This means that if not changed, the test case would fail with a (presumably) undefined function call, as the function will not exist anymore.
+
+The function in question is `waitForCondition()`. The deprecated piece of code is global and not namespaced, and thus does not follow modern JavaScript development practices. To fix this, we can change the function call to the namespaced `TestUtils` class, via `TestUtils.waitForCondition()`. Although these two functions are identical for the purposes of this test, `TestUtils.waitForCondition()` is a more modular implementation of waiting for asynchronous function calls to complete that allows for setting optional parameters such as the delay between polls, maximum number of tries, and a timeout.
+
+# Proposed Solution
+
+The proposed solution is very simple. We need to replace instances of `waitForCondition()` with `TestUtils.waitForCondition()`. Since `TestUtils.js` exports `TestUtils`, and our test file already imports this in a parent file, we do not need to include an include statement to import the js file. Instead, we can simply change calls to `waitForCondition()` to `TestUtils.waitForCondition()`.
+
+`TestUtils.waitForCondition()` takes a lambda function as its first argument, where the function is a predicate on what we're waiting for. In this example, we're testing for the condition `() => navbar.hasAttribute("overflowing")`, which is a function that takes 0 arguments and maps to the boolean function `hasAttribute()`. when `navbar.hasAttribute("overflowing")` returns true (when the page overflows), the test continues.
+
+# Testing
+
+Testing also proved to be relatively easy. Upon a bit of investigation, I discovered that FireFox comes bundled with mochitest, which is an automated testing framework built upon the MochiKit JavaScript libraries. We can give mochitest individual tests to run, so that we're not just running the entire front-end testing framework and testing components that this fix wouldn't affect.
+
+To run some tests against our proposed solution, we can use the following command: `./mach mochitest browser/components/customizableui/test/browser_913972_currentset_overflow.js`. Running this test (before our change was implemented) produced the following output:
+
+```
+Overall Summary
+===============
+
+mochitest-browser
+~~~~~~~~~~~~~~~~~
+Ran 23 checks (1 tests, 22 subtests)
+Expected results: 23
+OK
+```
+
+Running this test with our proposed solution also produced identical output:
+
+```
+Overall Summary
+===============
+
+mochitest-browser
+~~~~~~~~~~~~~~~~~
+Ran 23 checks (1 tests, 22 subtests)
+Expected results: 23
+OK
+```
+
+To make sure that the test was actually working, I opted to omit the `waitForCondition()` lines completely and see if the tests would still pass. They failed with the following output:
+
+```
+Overall Summary
+===============
+
+mochitest-browser
+~~~~~~~~~~~~~~~~~
+Ran 23 checks (1 tests, 22 subtests)
+Expected results: 21
+Unexpected results: 2
+  subtest: 2 (2 fail)
+
+Unexpected Results
+------------------
+browser/components/customizableui/test/browser_913972_currentset_overflow.js
+  FAIL Should have an overflowing toolbar. - 
+Stack trace:
+chrome://mochikit/content/browser-test.js:test_ok:1305
+chrome://mochitests/content/browser/browser/components/customizableui/test/browser_913972_currentset_overflow.js:null:22
+chrome://mochikit/content/browser-test.js:Tester_execTest/<:1106
+chrome://mochikit/content/browser-test.js:Tester_execTest:1097
+chrome://mochikit/content/browser-test.js:nextTest/<:995
+chrome://mochikit/content/tests/SimpleTest/SimpleTest.js:SimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<:803
+  FAIL Should have fewer children. - 
+Stack trace:
+chrome://mochikit/content/browser-test.js:test_ok:1305
+chrome://mochitests/content/browser/browser/components/customizableui/test/browser_913972_currentset_overflow.js:null:24
+chrome://mochikit/content/browser-test.js:Tester_execTest/<:1106
+chrome://mochikit/content/browser-test.js:Tester_execTest:1097
+chrome://mochikit/content/browser-test.js:nextTest/<:995
+chrome://mochikit/content/tests/SimpleTest/SimpleTest.js:SimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<:803
+```
+
+The test fails with `FAIL: Should have an overflowing toolbar`. This makes sense because by omitting the `waitForCondition()` call to ensure that there is an overflowing toolbar, the code simply continues on and runs because it does not wait for the asynchronous function to ensure that there is in fact an overflowing toolbar.
+
+Thus, we can conclude that our proposed change did in fact work.
+
+It should also be noted that doing a full run of all of the tests (after the test was confirmed working by our minor test cases) also passed.


### PR DESCRIPTION
This PR is related to issue Bugzilla issue 1530785 (https://bugzilla.mozilla.org/show_bug.cgi?id=1530785).

The code fixes a test to not use deprecated code anymore. Details and methodology is described in `doc/a3.md`, with a patch file located in `doc/1530785.patch`.