### PR TITLE
Update findBar.inc.css

### DIFF
--- a/toolkit/themes/shared/findBar.inc.css
+++ b/toolkit/themes/shared/findBar.inc.css
@@ -35,6 +35,7 @@ findbar[noanim] {
 
 .findbar-closebutton {
   padding: 0 8px;
+  -moz-box-ordinal-group: 0 !important;
 }
 
 /* Search field */


### PR DESCRIPTION
The edit button can be moved out of sight by the status text of the find bar. See
https://bugzilla.mozilla.org/show_bug.cgi?id=1466346 and
https://bugzilla.mozilla.org/show_bug.cgi?id=1222710