### PR TITLE
Bug 1587031 - Removed two unused prefs from firefox.js

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -1584,9 +1584,6 @@ pref("browser.contentblocking.database.enabled", true);
 
 pref("dom.storage_access.enabled", true);
 
-pref("browser.contentblocking.control-center.ui.showBlockedLabels", true);
-pref("browser.contentblocking.control-center.ui.showAllowedLabels", false);
-
 pref("browser.contentblocking.cryptomining.preferences.ui.enabled", true);
 pref("browser.contentblocking.fingerprinting.preferences.ui.enabled", true);
 

--- a/doc/1587031.patch
+++ b/doc/1587031.patch
@@ -1,0 +1,27 @@
+From 2be079f7fb117ae126da18da722c21d65c060c35 Mon Sep 17 00:00:00 2001
+From: lucyw93 <lwang5829@gmail.com>
+Date: Wed, 13 Nov 2019 17:25:38 -0500
+Subject: [PATCH] Bug 1587031 - Removed unused
+ browser.contentblocking.control-center.ui prefs from firefox.js.
+
+---
+ browser/app/profile/firefox.js | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/browser/app/profile/firefox.js b/browser/app/profile/firefox.js
+index d8abd29..24f698a 100644
+--- a/browser/app/profile/firefox.js
++++ b/browser/app/profile/firefox.js
+@@ -1584,9 +1584,6 @@ pref("browser.contentblocking.database.enabled", true);
+ 
+ pref("dom.storage_access.enabled", true);
+ 
+-pref("browser.contentblocking.control-center.ui.showBlockedLabels", true);
+-pref("browser.contentblocking.control-center.ui.showAllowedLabels", false);
+-
+ pref("browser.contentblocking.cryptomining.preferences.ui.enabled", true);
+ pref("browser.contentblocking.fingerprinting.preferences.ui.enabled", true);
+ 
+-- 
+2.10.0
+

--- a/doc/a3.md
+++ b/doc/a3.md
@@ -1,0 +1,28 @@
+URL to bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1587031
+PR link: https://github.com/mozilla/gecko-dev/pull/494
+
+### Diagnosis of the Bug
+
+The bug was opened by the reporter to remove two lines of unused code in the _browser/app/profile/firefox.js_ file. The file to be modified is a preference file, which contains the default non-static preferences used specifically for desktop Firefox. A preference in Mozilla is a defined behavior or value which could be changed and set. A preference could be set by calling one of the four functions: _pref()_, _user_pref()_, _sticky_pref()_, and _lockPref()_. The two lines the reporter asked to remove are pref() calls, which set default preferences.
+
+The benefit to fixing this bug would be to improve code quality by keeping code more concise and getting rid of unused code. Keeping the code clean could help developpers to better understand the code and saves them time on debugging the code. Also, as the project gets larger, more features and modifications would be added, hence a more concise code would be easier to maintain.
+
+However, the risk to removing the two lines of default preference settings would be if the reporter mistakenly thought it was unused when in fact it played a role in defining the UI. But since the search results from _searchfox.org_ suggests that the two values being set are not used anywhere else except being defined in the preference file, the code should be safe to remove.
+
+### Proposed Solution
+
+As requested by the reporter, the solution to resolving this bug would be to remove the two lines of default preference setting code in the _browser/app/profile/firefox.js_ file:
+
+```
+// lines 1584 - 1585
+pref("browser.contentblocking.control-center.ui.showBlockedLabels", true);
+pref("browser.contentblocking.control-center.ui.showAllowedLabels", false);
+```
+
+Since this bug is a 'task' to clean up unused code rather than a 'defect', no additional code change would be required. Commenting out the two lines of code would also achieve the same desired result, but removing it completely will help make the code more readable and clean.
+
+When performing this type of code clean up task, the first step to do is to make sure the code piece is not used anywhere else in the project. After making sure that the lines are safe to be removed, delete the specified lines from the file and any extra blank lines to ensure code styling is consistent. After the correction to the bug has been made, run tests/inspections to make sure the modifications did not cause any errors or regressions.
+
+### Testing Procedure
+
+Since this task only requires removing two lines of unused default preference code, which is not used in any other files according to results on _searchfog.org_, we need to check that the lines are properly removed from the preference file after the fix. In other words, before the patch the _browser/app/profile/firefox.js_ file contains lines 1584 and 1585 as noted above, and after the patch these two lines should no longer be there, while everything else stays the same. The absence of these two lines would indicate that the bug was fixed successfully.

--- a/doc/a3.md
+++ b/doc/a3.md
@@ -1,5 +1,8 @@
 URL to bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1587031
+
 PR link: https://github.com/mozilla/gecko-dev/pull/494
+
+path file link: https://github.com/lucyw93/gecko-dev/blob/master/doc/1587031.patch
 
 ### Diagnosis of the Bug
 


### PR DESCRIPTION
Removed two unused browser.contentblocking.control-center.ui prefs from mozilla-central/browser/app/profile/firefox.js