### PR TITLE
Bug 1590232 - Added one line change to fix the bug.

### DIFF
--- a/dom/ipc/DocShellMessageUtils.h
+++ b/dom/ipc/DocShellMessageUtils.h
@@ -11,6 +11,7 @@
 #include "nsCOMPtr.h"
 #include "nsDocShellLoadState.h"
 #include "mozilla/ScrollbarPreferences.h"
+#include "mozilla/ipc/IPDLParamTraits.h" // Our bug fix for the IPDLParamTraits struct
 
 namespace mozilla {
 namespace ipc {


### PR DESCRIPTION
Added code <#include "mozilla/ipc/IPDLParamTraits.h"> on line 14 in file DocShellMessageUtils.h to fix the bug.  This line of code is adding a missing header file that contains one of the structs being declared in this file.