### PR TITLE
Bug 1510970 - Changed redundant ternary operators to remove the redun…

### DIFF
--- a/mobile/android/geckoview/src/main/java/org/mozilla/gecko/gfx/GeckoSurface.java
+++ b/mobile/android/geckoview/src/main/java/org/mozilla/gecko/gfx/GeckoSurface.java
@@ -44,8 +44,8 @@ public final class GeckoSurface extends Surface {
 
         readFromParcel(p);
         mHandle = p.readInt();
-        mIsSingleBuffer = p.readByte() == 1 ? true : false;
-        mIsAvailable = (p.readByte() == 1 ? true : false);
+        mIsSingleBuffer = p.readByte() == 1;
+        mIsAvailable = p.readByte() == 1;
         mMyPid = p.readInt();
 
         dummy.release();

--- a/mobile/android/geckoview/src/main/java/org/mozilla/geckoview/GeckoRuntimeSettings.java
+++ b/mobile/android/geckoview/src/main/java/org/mozilla/geckoview/GeckoRuntimeSettings.java
@@ -637,7 +637,7 @@ public final class GeckoRuntimeSettings extends RuntimeSettings {
      * @return Whether web fonts support is enabled.
      */
     public boolean getWebFontsEnabled() {
-        return mWebFonts.get() != 0 ? true : false;
+        return mWebFonts.get() != 0;
     }
 
     /**


### PR DESCRIPTION
…dant conditional operators Java warning.

Fixed the warning in these two files that said conditional expressions are redundant with more readable and efficient code.