### PR TITLE
Bug 1620935

### DIFF
--- a/devtools/client/responsive/types.js
+++ b/devtools/client/responsive/types.js
@@ -47,7 +47,7 @@ const device = {
   touch: PropTypes.bool,
 
   // The operating system of the device
-  os: PropTypes.String,
+  os: PropTypes.string,
 
   // Whether or not the device is displayed in the device selector
   displayed: PropTypes.bool,


### PR DESCRIPTION
String with an uppercase 's' is not a PropType, thus giving invalid type warnings. Changed it to a lowercase 's' in line 50 to remove warnings