### PR TITLE
Import missing macro std::arch::is_aarch64_feature_detected

### DIFF
--- a/dom/canvas/ClientWebGLContext.cpp
+++ b/dom/canvas/ClientWebGLContext.cpp
@@ -4015,6 +4015,7 @@ void ClientWebGLContext::TexImage(uint8_t funcDims, GLenum imageTarget,
 
   // -
   bool isDataUpload = false;
+  bool isAndroidVideo = false;
   auto desc = [&]() -> Maybe<webgl::TexUnpackBlobDesc> {
     if (src.mPboOffset) {
       isDataUpload = true;
@@ -4068,6 +4069,7 @@ void ClientWebGLContext::TexImage(uint8_t funcDims, GLenum imageTarget,
     }
 
     if (src.mDomElem) {
+      isAndroidVideo = src.mDomElem->IsHTMLElement(nsGkAtoms::video);
       return webgl::FromDomElem(*this, imageTarget, explicitSize,
                                 *(src.mDomElem), src.mOut_error);
     }
@@ -4098,7 +4100,10 @@ void ClientWebGLContext::TexImage(uint8_t funcDims, GLenum imageTarget,
     }
   }
 
-  const auto& rawUnpacking = State().mPixelUnpackState;
+  auto rawUnpacking = State().mPixelUnpackState;
+  if (isAndroidVideo) {
+    rawUnpacking.mFlipY = !rawUnpacking.mFlipY;
+  }
   const bool isSubrect =
       (rawUnpacking.mUnpackImageHeight || rawUnpacking.mUnpackSkipImages ||
        rawUnpacking.mUnpackRowLength || rawUnpacking.mUnpackSkipRows ||

--- a/dom/canvas/TexUnpackBlob.cpp
+++ b/dom/canvas/TexUnpackBlob.cpp
@@ -714,7 +714,7 @@ Maybe<std::string> BlitPreventReason(const int32_t level, const ivec3& offset,
     if (premultReason) return premultReason;
 
     if (pi.format != LOCAL_GL_RGBA) {
-      return "`format` is not RGBA";
+      //return "`format` is not RGBA";
     }
 
     if (pi.type != LOCAL_GL_UNSIGNED_BYTE) {

--- a/dom/canvas/WebGLContext.cpp
+++ b/dom/canvas/WebGLContext.cpp
@@ -596,6 +596,9 @@ RefPtr<WebGLContext> WebGLContext::Create(HostWebGLContext& host,
     if (kIsMacOS) {
       types[layers::SurfaceDescriptor::TSurfaceDescriptorMacIOSurface] = true;
     }
+    if (kIsAndroid) {
+      types[layers::SurfaceDescriptor::TSurfaceTextureDescriptor] = true;
+    }
     return types;
   };
 

--- a/dom/vr/VRServiceTest.cpp
+++ b/dom/vr/VRServiceTest.cpp
@@ -95,10 +95,15 @@ void VRMockDisplay::Create() {
   state.eyeResolution.width = 1836;   // 1080 * 1.7
   state.eyeResolution.height = 2040;  // 1200 * 1.7
 
+  float identity[16] = { 
+      1.0f, 0.0f, 0.0f, 0.0f,
+      0.0f, 1.0f, 0.0f, 0.0f,
+      0.0f, 0.0f, 1.0f, 0.0f,
+      0.0f, 0.0f, 0.0f, 1.0f
+  };
+
   for (uint32_t eye = 0; eye < VRDisplayState::NumEyes; ++eye) {
-    state.eyeTranslation[eye].x = 0.0f;
-    state.eyeTranslation[eye].y = 0.0f;
-    state.eyeTranslation[eye].z = 0.0f;
+    memcpy(state.eyeTransform[eye], identity, sizeof(identity));
     state.eyeFOV[eye] = gfx::VRFieldOfView(45.0, 45.0, 45.0, 45.0);
   }
 
@@ -106,25 +111,8 @@ void VRMockDisplay::Create() {
   state.stageSize.width = 1.0f;
   state.stageSize.height = 1.0f;
 
-  state.sittingToStandingTransform[0] = 1.0f;
-  state.sittingToStandingTransform[1] = 0.0f;
-  state.sittingToStandingTransform[2] = 0.0f;
-  state.sittingToStandingTransform[3] = 0.0f;
-
-  state.sittingToStandingTransform[4] = 0.0f;
-  state.sittingToStandingTransform[5] = 1.0f;
-  state.sittingToStandingTransform[6] = 0.0f;
-  state.sittingToStandingTransform[7] = 0.0f;
-
-  state.sittingToStandingTransform[8] = 0.0f;
-  state.sittingToStandingTransform[9] = 0.0f;
-  state.sittingToStandingTransform[10] = 1.0f;
-  state.sittingToStandingTransform[11] = 0.0f;
-
-  state.sittingToStandingTransform[12] = 0.0f;
+  memcpy(state.sittingToStandingTransform, identity, sizeof(identity));
   state.sittingToStandingTransform[13] = 0.75f;
-  state.sittingToStandingTransform[14] = 0.0f;
-  state.sittingToStandingTransform[15] = 1.0f;
 
   VRHMDSensorState& sensorState = SensorState();
   gfx::Quaternion rot;
@@ -221,9 +209,9 @@ void VRMockDisplay::SetEyeOffset(VREye aEye, double aOffsetX, double aOffsetY,
                                      ? gfx::VRDisplayState::Eye_Left
                                      : gfx::VRDisplayState::Eye_Right;
   VRDisplayState& state = DisplayState();
-  state.eyeTranslation[eye].x = (float)aOffsetX;
-  state.eyeTranslation[eye].y = (float)aOffsetY;
-  state.eyeTranslation[eye].z = (float)aOffsetZ;
+  state.eyeTransform[eye][12] = (float)aOffsetX;
+  state.eyeTransform[eye][13] = (float)aOffsetY;
+  state.eyeTransform[eye][14] = (float)aOffsetZ;
 }
 
 bool VRMockDisplay::CapPosition() const {

--- a/dom/vr/XRBoundedReferenceSpace.cpp
+++ b/dom/vr/XRBoundedReferenceSpace.cpp
@@ -58,7 +58,7 @@ XRBoundedReferenceSpace::GetOffsetReferenceSpace(
   // https://immersive-web.github.io/webxr/#dom-xrreferencespace-getoffsetreferencespace
   // Set offsetSpace’s origin offset to the result of multiplying base’s origin offset
   // by originOffset in the relevant realm of base.
-  offsetReferenceSpace->mOriginOffset = mOriginOffset * aOffsetTransform.RawTransform();
+  offsetReferenceSpace->mOriginOffset = aOffsetTransform.RawTransform() * mOriginOffset;
 
   return offsetReferenceSpace.forget();
 }

--- a/dom/vr/XRBoundedReferenceSpace.cpp
+++ b/dom/vr/XRBoundedReferenceSpace.cpp
@@ -51,22 +51,14 @@ void XRBoundedReferenceSpace::GetBoundsGeometry(
 
 already_AddRefed<XRReferenceSpace>
 XRBoundedReferenceSpace::GetOffsetReferenceSpace(
-    const XRRigidTransform& aOriginOffset) {
+    const XRRigidTransform& aOffsetTransform) {
   RefPtr<XRBoundedReferenceSpace> offsetReferenceSpace =
       new XRBoundedReferenceSpace(GetParentObject(), mSession, mNativeOrigin);
 
-  // https://immersive-web.github.io/webxr/#multiply-transforms
-  // An XRRigidTransform is essentially a rotation followed by a translation
-  gfx::QuaternionDouble otherOrientation = aOriginOffset.RawOrientation();
-  // The resulting rotation is the two combined
-  offsetReferenceSpace->mOriginOffsetOrientation =
-      mOriginOffsetOrientation * otherOrientation;
-  // We first apply the rotation of aOriginOffset to
-  // mOriginOffsetPosition offset, then translate by the offset of
-  // aOriginOffset
-  offsetReferenceSpace->mOriginOffsetPosition =
-      otherOrientation.RotatePoint(mOriginOffsetPosition) +
-      aOriginOffset.RawPosition();
+  // https://immersive-web.github.io/webxr/#dom-xrreferencespace-getoffsetreferencespace
+  // Set offsetSpace’s origin offset to the result of multiplying base’s origin offset
+  // by originOffset in the relevant realm of base.
+  offsetReferenceSpace->mOriginOffset = mOriginOffset * aOffsetTransform.RawTransform();
 
   return offsetReferenceSpace.forget();
 }

--- a/dom/vr/XRFrame.cpp
+++ b/dom/vr/XRFrame.cpp
@@ -84,12 +84,7 @@ already_AddRefed<XRViewerPose> XRFrame::GetViewerPose(
     headTransform.SetRotationFromQuaternion(viewerOrientation);
     headTransform.PostTranslate(viewerPosition);
 
-    gfx::Matrix4x4Double originTransform;
-    originTransform.SetRotationFromQuaternion(
-        aReferenceSpace.GetEffectiveOriginOrientation().Inverse());
-    originTransform.PreTranslate(-aReferenceSpace.GetEffectiveOriginPosition());
-
-    headTransform *= originTransform;
+    headTransform *= aReferenceSpace.GetEffectiveOriginTransform().Inverse();
 
     viewerPose = mSession->PooledViewerPose(headTransform, emulatedPosition);
 
@@ -159,13 +154,9 @@ already_AddRefed<XRPose> XRFrame::GetPose(const XRSpace& aSpace,
   // TODO (Bug 1616393) - Check if poses must be limited:
   // https://immersive-web.github.io/webxr/#poses-must-be-limited
 
-  const bool emulatedPosition = aSpace.IsPositionEmulated();
-  gfx::Matrix4x4Double base;
-  base.SetRotationFromQuaternion(
-      aBaseSpace.GetEffectiveOriginOrientation().Inverse());
-  base.PreTranslate(-aBaseSpace.GetEffectiveOriginPosition());
+  const bool emulatedPosition = aSpace.IsPositionEmulated() || aBaseSpace.IsPositionEmulated();
 
-  gfx::Matrix4x4Double matrix = aSpace.GetEffectiveOriginTransform() * base;
+  gfx::Matrix4x4Double matrix = aSpace.GetEffectiveOriginTransform() * aBaseSpace.GetEffectiveOriginTransform().Inverse();
 
   RefPtr<XRRigidTransform> transform = new XRRigidTransform(mParent, matrix);
   RefPtr<XRPose> pose = new XRPose(mParent, transform, emulatedPosition);

--- a/dom/vr/XRInputSource.cpp
+++ b/dom/vr/XRInputSource.cpp
@@ -85,6 +85,16 @@ nsTArray<nsString> GetInputSourceProfile(gfx::VRControllerType aType) {
       id.AssignLiteral("generic-trigger-squeeze-thumbstick");
       profile.AppendElement(id);
       break;
+    case gfx::VRControllerType::OculusTouch3:
+      id.AssignLiteral("oculus-touch-v3");
+      profile.AppendElement(id);
+      id.AssignLiteral("oculus-touch-v2");
+      profile.AppendElement(id);
+      id.AssignLiteral("oculus-touch");
+      profile.AppendElement(id);
+      id.AssignLiteral("generic-trigger-squeeze-thumbstick");
+      profile.AppendElement(id);
+      break;
     case gfx::VRControllerType::PicoGaze:
       id.AssignLiteral("pico-gaze");
       profile.AppendElement(id);

--- a/dom/vr/XRNativeOriginLocal.cpp
+++ b/dom/vr/XRNativeOriginLocal.cpp
@@ -16,20 +16,7 @@ XRNativeOriginLocal::XRNativeOriginLocal(gfx::VRDisplayClient* aDisplay)
 }
 
 gfx::PointDouble3D XRNativeOriginLocal::GetPosition() {
-  // Keep returning {0,0,0} until a position can be found
-  if (!mInitialPositionValid) {
-    const gfx::VRHMDSensorState& sensorState = mDisplay->GetSensorState();
-    gfx::PointDouble3D origin;
-    if (sensorState.flags & gfx::VRDisplayCapabilityFlags::Cap_Position ||
-        sensorState.flags &
-            gfx::VRDisplayCapabilityFlags::Cap_PositionEmulated) {
-      mInitialPosition.x = sensorState.pose.position[0];
-      mInitialPosition.y = sensorState.pose.position[1];
-      mInitialPosition.z = sensorState.pose.position[2];
-      mInitialPositionValid = true;
-    }
-  }
-  return mInitialPosition;
+  return { };
 }
 
 }  // namespace dom

--- a/dom/vr/XRNativeOriginLocalFloor.cpp
+++ b/dom/vr/XRNativeOriginLocalFloor.cpp
@@ -30,9 +30,9 @@ gfx::PointDouble3D XRNativeOriginLocalFloor::GetPosition() {
       mDisplay->GetDisplayInfo().GetSittingToStandingTransform();
   if (!mInitialPositionValid || standing != mStandingTransform) {
     const gfx::VRHMDSensorState& sensorState = mDisplay->GetSensorState();
-    mInitialPosition.x = sensorState.pose.position[0];
+    mInitialPosition.x = 0;
     mInitialPosition.y = -mFloorRandom - standing._42;
-    mInitialPosition.z = sensorState.pose.position[2];
+    mInitialPosition.z = 0;
     mInitialPositionValid = true;
     mStandingTransform = standing;
   }

--- a/dom/vr/XRReferenceSpace.cpp
+++ b/dom/vr/XRReferenceSpace.cpp
@@ -25,7 +25,7 @@ already_AddRefed<XRReferenceSpace> XRReferenceSpace::GetOffsetReferenceSpace(
   // https://immersive-web.github.io/webxr/#dom-xrreferencespace-getoffsetreferencespace
   // Set offsetSpace’s origin offset to the result of multiplying base’s origin offset by
   // originOffset in the relevant realm of base.
-  offsetReferenceSpace->mOriginOffset = mOriginOffset * aOffsetTransform.RawTransform();
+  offsetReferenceSpace->mOriginOffset = aOffsetTransform.RawTransform() * mOriginOffset;
 
   return offsetReferenceSpace.forget();
 }

--- a/dom/vr/XRReferenceSpace.cpp
+++ b/dom/vr/XRReferenceSpace.cpp
@@ -18,22 +18,14 @@ XRReferenceSpace::XRReferenceSpace(nsIGlobalObject* aParent,
     : XRSpace(aParent, aSession, aNativeOrigin), mType(aType) {}
 
 already_AddRefed<XRReferenceSpace> XRReferenceSpace::GetOffsetReferenceSpace(
-    const XRRigidTransform& aOriginOffset) {
+    const XRRigidTransform& aOffsetTransform) {
   RefPtr<XRReferenceSpace> offsetReferenceSpace =
       new XRReferenceSpace(GetParentObject(), mSession, mNativeOrigin, mType);
 
-  // https://immersive-web.github.io/webxr/#multiply-transforms
-  // An XRRigidTransform is essentially a rotation followed by a translation
-  gfx::QuaternionDouble otherOrientation = aOriginOffset.RawOrientation();
-  // The resulting rotation is the two combined
-  offsetReferenceSpace->mOriginOffsetOrientation =
-      mOriginOffsetOrientation * otherOrientation;
-  // We first apply the rotation of aOriginOffset to
-  // mOriginOffsetPosition offset, then translate by the offset of
-  // aOriginOffset
-  offsetReferenceSpace->mOriginOffsetPosition =
-      otherOrientation.RotatePoint(mOriginOffsetPosition) +
-      aOriginOffset.RawPosition();
+  // https://immersive-web.github.io/webxr/#dom-xrreferencespace-getoffsetreferencespace
+  // Set offsetSpace’s origin offset to the result of multiplying base’s origin offset by
+  // originOffset in the relevant realm of base.
+  offsetReferenceSpace->mOriginOffset = mOriginOffset * aOffsetTransform.RawTransform();
 
   return offsetReferenceSpace.forget();
 }

--- a/dom/vr/XRRigidTransform.cpp
+++ b/dom/vr/XRRigidTransform.cpp
@@ -110,6 +110,10 @@ gfx::PointDouble3D XRRigidTransform::RawPosition() const {
   return mRawPosition;
 }
 
+gfx::Matrix4x4Double XRRigidTransform::RawTransform() const {
+  return mRawTransformMatrix;
+}
+
 void XRRigidTransform::Update(const gfx::PointDouble3D& aPosition,
                               const gfx::QuaternionDouble& aOrientation) {
   mNeedsUpdate = true;

--- a/dom/vr/XRRigidTransform.h
+++ b/dom/vr/XRRigidTransform.h
@@ -33,6 +33,7 @@ class XRRigidTransform final : public nsWrapperCache {
   XRRigidTransform& operator=(const XRRigidTransform& aOther);
   gfx::QuaternionDouble RawOrientation() const;
   gfx::PointDouble3D RawPosition() const;
+  gfx::Matrix4x4Double RawTransform() const;
   void Update(const gfx::PointDouble3D& aPosition,
               const gfx::QuaternionDouble& aOrientation);
   void Update(const gfx::Matrix4x4Double& aTransform);

--- a/dom/vr/XRSession.cpp
+++ b/dom/vr/XRSession.cpp
@@ -232,6 +232,14 @@ XRRenderState* XRSession::RenderState() { return mActiveRenderState; }
 
 XRInputSourceArray* XRSession::InputSources() { return mInputSources; }
 
+Nullable<float> XRSession::GetFrameRate() {
+  return {};
+}
+
+void XRSession::GetSupportedFrameRates(JSContext*, JS::MutableHandle<JSObject*> aRetVal) {
+  aRetVal.set(nullptr);
+}
+
 // https://immersive-web.github.io/webxr/#apply-the-pending-render-state
 void XRSession::ApplyPendingRenderState() {
   if (mPendingRenderState == nullptr) {
@@ -391,6 +399,29 @@ already_AddRefed<Promise> XRSession::RequestReferenceSpace(
   }
 
   promise->MaybeResolve(space);
+  return promise.forget();
+}
+
+already_AddRefed<Promise> XRSession::UpdateTargetFrameRate(float aRate, ErrorResult& aRv) {
+  nsCOMPtr<nsIGlobalObject> global = GetParentObject();
+  NS_ENSURE_TRUE(global, nullptr);
+
+  RefPtr<Promise> promise = Promise::Create(global, aRv);
+  NS_ENSURE_TRUE(!aRv.Failed(), nullptr);
+
+  if (mEnded) {
+    promise->MaybeRejectWithInvalidStateError(
+        "UpdateTargetFrameRate can not be called on an XRSession that has ended.");
+    return promise.forget();
+  }
+
+  // https://immersive-web.github.io/webxr/#dom-xrsession-updatetargetframerate
+  // TODO: Validate the rate with the frame rates supported from the device.
+  // We add a no op for now to avoid JS exceptions related to undefined method.
+  // The spec states that user agent MAY use rate to calculate a new display frame rate,
+  // so it's fine to let the default frame rate for now.
+
+  promise->MaybeResolve(JS::UndefinedHandleValue);
   return promise.forget();
 }
 

--- a/dom/vr/XRSession.h
+++ b/dom/vr/XRSession.h
@@ -67,6 +67,8 @@ class XRSession final : public DOMEventTargetHelper, public nsARefreshObserver {
   XRVisibilityState VisibilityState() const;
   XRRenderState* RenderState();
   XRInputSourceArray* InputSources();
+  Nullable<float> GetFrameRate();
+  void GetSupportedFrameRates(JSContext* aJSContext, JS::MutableHandle<JSObject*> aRetval);
 
   // WebIDL Methods
   void UpdateRenderState(const XRRenderStateInit& aNewState, ErrorResult& aRv);
@@ -76,6 +78,7 @@ class XRSession final : public DOMEventTargetHelper, public nsARefreshObserver {
                                 mozilla::ErrorResult& aError);
   void CancelAnimationFrame(int32_t aHandle, mozilla::ErrorResult& aError);
   already_AddRefed<Promise> End(ErrorResult& aRv);
+  already_AddRefed<Promise> UpdateTargetFrameRate(float aRate, ErrorResult& aRv);
 
   // WebIDL Events
   IMPL_EVENT_HANDLER(end);

--- a/dom/vr/XRSpace.h
+++ b/dom/vr/XRSpace.h
@@ -35,8 +35,7 @@ class XRSpace : public DOMEventTargetHelper {
   XRNativeOrigin* GetNativeOrigin() const;
 
   // Non webIDL Members
-  gfx::QuaternionDouble GetEffectiveOriginOrientation() const;
-  gfx::PointDouble3D GetEffectiveOriginPosition() const;
+  gfx::Matrix4x4Double GetNativeOriginTransform() const;
   gfx::Matrix4x4Double GetEffectiveOriginTransform() const;
   virtual bool IsPositionEmulated() const;
 
@@ -48,8 +47,7 @@ class XRSpace : public DOMEventTargetHelper {
 
   // https://immersive-web.github.io/webxr/#xrspace-origin-offset
   // Origin Offset, represented as a rigid transform
-  gfx::PointDouble3D mOriginOffsetPosition;
-  gfx::QuaternionDouble mOriginOffsetOrientation;
+  gfx::Matrix4x4Double mOriginOffset;
 };
 
 }  // namespace dom

--- a/dom/vr/XRView.cpp
+++ b/dom/vr/XRView.cpp
@@ -36,8 +36,7 @@ NS_IMPL_CYCLE_COLLECTION_UNROOT_NATIVE(XRView, Release)
 XRView::XRView(nsISupports* aParent, const XREye& aEye)
     : mParent(aParent),
       mEye(aEye),
-      mPosition(gfx::PointDouble3D()),
-      mOrientation(gfx::QuaternionDouble()),
+      mEyeTransform(gfx::Matrix4x4Double()),
       mJSProjectionMatrix(nullptr) {
   mozilla::HoldJSObjects(this);
 }
@@ -49,14 +48,12 @@ JSObject* XRView::WrapObject(JSContext* aCx,
   return XRView_Binding::Wrap(aCx, this, aGivenProto);
 }
 
-void XRView::Update(const gfx::PointDouble3D& aPosition,
-                    const gfx::QuaternionDouble& aOrientation,
+void XRView::Update(const gfx::Matrix4x4Double& aEyeTransform,
                     const gfx::Matrix4x4& aProjectionMatrix) {
-  mPosition = aPosition;
-  mOrientation = aOrientation;
+  mEyeTransform = aEyeTransform;
   mProjectionMatrix = aProjectionMatrix;
   if (mTransform) {
-    mTransform->Update(aPosition, aOrientation);
+    mTransform->Update(mEyeTransform);
   }
   if (aProjectionMatrix != mProjectionMatrix) {
     mProjectionNeedsUpdate = true;
@@ -87,7 +84,7 @@ void XRView::GetProjectionMatrix(JSContext* aCx,
 
 already_AddRefed<XRRigidTransform> XRView::GetTransform(ErrorResult& aRv) {
   if (!mTransform) {
-    mTransform = new XRRigidTransform(mParent, mPosition, mOrientation);
+    mTransform = new XRRigidTransform(mParent, mEyeTransform);
   }
   RefPtr<XRRigidTransform> transform = mTransform;
   return transform.forget();

--- a/dom/vr/XRView.h
+++ b/dom/vr/XRView.h
@@ -25,8 +25,7 @@ class XRView final : public nsWrapperCache {
 
   explicit XRView(nsISupports* aParent, const XREye& aEye);
 
-  void Update(const gfx::PointDouble3D& aPosition,
-              const gfx::QuaternionDouble& aOrientation,
+  void Update(const gfx::Matrix4x4Double& aEyeTransform,
               const gfx::Matrix4x4& aProjectionMatrix);
   // WebIDL Boilerplate
   nsISupports* GetParentObject() const { return mParent; }
@@ -44,8 +43,7 @@ class XRView final : public nsWrapperCache {
 
   nsCOMPtr<nsISupports> mParent;
   XREye mEye;
-  gfx::PointDouble3D mPosition;
-  gfx::QuaternionDouble mOrientation;
+  gfx::Matrix4x4Double mEyeTransform;
   gfx::Matrix4x4 mProjectionMatrix;
   JS::Heap<JSObject*> mJSProjectionMatrix;
   bool mProjectionNeedsUpdate = true;

--- a/dom/webidl/WebXR.webidl
+++ b/dom/webidl/WebXR.webidl
@@ -43,12 +43,16 @@ interface XRSession : EventTarget {
   readonly attribute XRVisibilityState visibilityState;
   [SameObject] readonly attribute XRRenderState renderState;
   [SameObject] readonly attribute XRInputSourceArray inputSources;
+  readonly attribute float? frameRate;
+  readonly attribute Float32Array? supportedFrameRates;
 
   // Methods
   [Throws]
   void updateRenderState(optional XRRenderStateInit state = {});
   [NewObject]
   Promise<XRReferenceSpace> requestReferenceSpace(XRReferenceSpaceType type);
+  [NewObject]
+  Promise<void> updateTargetFrameRate(float rate);
 
   [Throws]
   long requestAnimationFrame(XRFrameRequestCallback callback);

--- a/gfx/gl/AndroidSurfaceTexture.cpp
+++ b/gfx/gl/AndroidSurfaceTexture.cpp
@@ -9,6 +9,8 @@
 #include "GLContextEGL.h"
 #include "GLBlitHelper.h"
 #include "GLImages.h"
+#include "mozilla/gfx/Logging.h"
+#include "mozilla/layers/LayersSurfaces.h"
 
 #ifdef MOZ_WIDGET_ANDROID
 #  include "mozilla/java/GeckoSurfaceTextureNatives.h"
@@ -51,23 +53,24 @@ class AndroidSharedBlitGL final {
     }
   }
 
-  void Blit(layers::SurfaceTextureImage* img, const gfx::IntSize& imageSize) {
+#ifdef MOZ_WIDGET_ANDROID
+  void Blit(const java::GeckoSurfaceTexture::Ref& surfaceTexture,
+            const gfx::IntSize& imageSize) {
     StaticMutexAutoLock lock(sMutex);
     MOZ_ASSERT(sContext);
 
     // Setting overide also makes conext and surface current.
     sContext->SetEGLSurfaceOverride(mTargetSurface);
-#ifdef MOZ_WIDGET_ANDROID
-    sContext->BlitHelper()->BlitImage(img, imageSize, OriginPos::BottomLeft);
-#else
-    MOZ_CRASH("bad platform");
-#endif
+    DebugOnly<bool> rv = sContext->BlitHelper()->Blit(surfaceTexture, imageSize,
+                                                      OriginPos::BottomLeft);
+    MOZ_ASSERT(rv);
     sContext->SwapBuffers();
     // This method is called through binder IPC and could run on any thread in
     // the pool. Release the context and surface from this thread after use so
     // they can be bound to another thread later.
     UnmakeCurrent(sContext);
   }
+#endif
 
  private:
   static already_AddRefed<GLContextEGL> CreateContextImpl(bool aUseGles) {
@@ -173,9 +176,9 @@ class GLBlitterSupport final
         mSize(width, height) {}
 
   void Blit() {
-    RefPtr<layers::SurfaceTextureImage> img = new layers::SurfaceTextureImage(
-        mSourceTextureHandle, mSize, false, OriginPos::TopLeft);
-    mGl->Blit(img, mSize);
+    auto surfaceTexture =
+        java::GeckoSurfaceTexture::Lookup(mSourceTextureHandle);
+    mGl->Blit(surfaceTexture, mSize);
   }
 
  private:

--- a/gfx/gl/GLBlitHelper.h
+++ b/gfx/gl/GLBlitHelper.h
@@ -36,6 +36,10 @@ struct ID3D11Texture2D;
 class MacIOSurface;
 #endif
 
+#ifdef MOZ_WIDGET_ANDROID
+#  include "mozilla/java/GeckoSurfaceTextureWrappers.h"
+#endif
+
 namespace mozilla {
 
 namespace layers {
@@ -54,7 +58,7 @@ class SurfaceDescriptorDXGIYCbCr;
 #endif
 
 #ifdef MOZ_WIDGET_ANDROID
-class SurfaceTextureImage;
+class SurfaceTextureDescriptor;
 #endif
 
 #ifdef XP_MACOSX
@@ -177,9 +181,8 @@ class GLBlitHelper final {
   bool BlitPlanarYCbCr(const layers::PlanarYCbCrData&,
                        const gfx::IntSize& destSize, OriginPos destOrigin);
 #ifdef MOZ_WIDGET_ANDROID
-  // Blit onto the current FB.
-  bool BlitImage(layers::SurfaceTextureImage* stImage,
-                 const gfx::IntSize& destSize, OriginPos destOrigin) const;
+  bool Blit(const java::GeckoSurfaceTexture::Ref& surfaceTexture,
+            const gfx::IntSize& destSize, const OriginPos destOrigin) const;
 #endif
 #ifdef XP_MACOSX
   bool BlitImage(layers::MacIOSurfaceImage* srcImage,

--- a/gfx/layers/GLImages.cpp
+++ b/gfx/layers/GLImages.cpp
@@ -85,6 +85,14 @@ SurfaceTextureImage::SurfaceTextureImage(AndroidSurfaceTextureHandle aHandle,
       mHasAlpha(aHasAlpha) {
   MOZ_ASSERT(mHandle);
 }
+
+Maybe<SurfaceDescriptor> SurfaceTextureImage::GetDesc() {
+  SurfaceDescriptor sd = SurfaceTextureDescriptor(
+      mHandle, mSize,
+      mHasAlpha ? gfx::SurfaceFormat::R8G8B8A8 : gfx::SurfaceFormat::R8G8B8X8,
+      false /* NOT continuous */, false /* do not ignore transform */);
+  return Some(sd);
+}
 #endif
 
 }  // namespace layers

--- a/gfx/layers/GLImages.h
+++ b/gfx/layers/GLImages.h
@@ -59,6 +59,8 @@ class SurfaceTextureImage : public GLImage {
 
   SurfaceTextureImage* AsSurfaceTextureImage() override { return this; }
 
+  Maybe<SurfaceDescriptor> GetDesc() override;
+
   void RegisterSetCurrentCallback(UniquePtr<SetCurrentCallback> aCallback) {
     mSetCurrentCallback = std::move(aCallback);
   }

--- a/gfx/qcms/src/transform.rs
+++ b/gfx/qcms/src/transform.rs
@@ -56,6 +56,8 @@ use crate::{
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
+use std::arch::is_aarch64_feature_detected;
+
 pub const PRECACHE_OUTPUT_SIZE: usize = 8192;
 pub const PRECACHE_OUTPUT_MAX: usize = PRECACHE_OUTPUT_SIZE - 1;
 pub const FLOATSCALE: f32 = PRECACHE_OUTPUT_SIZE as f32;

--- a/gfx/vr/external_api/moz_external_vr.h
+++ b/gfx/vr/external_api/moz_external_vr.h
@@ -147,6 +147,7 @@ enum class VRControllerType : uint8_t {
   OculusGo,
   OculusTouch,
   OculusTouch2,
+  OculusTouch3,
   PicoGaze,
   PicoG2,
   PicoNeo2,

--- a/gfx/vr/external_api/moz_external_vr.h
+++ b/gfx/vr/external_api/moz_external_vr.h
@@ -48,7 +48,7 @@ namespace gfx {
 // running at the same time? Or...what if we have multiple
 // release builds running on same machine? (Bug 1563232)
 #define SHMEM_VERSION "0.0.11"
-static const int32_t kVRExternalVersion = 18;
+static const int32_t kVRExternalVersion = 19;
 
 // We assign VR presentations to groups with a bitmask.
 // Currently, we will only display either content or chrome.
@@ -344,7 +344,7 @@ struct VRDisplayState {
   VRDisplayCapabilityFlags capabilityFlags;
   VRDisplayBlendMode blendMode;
   VRFieldOfView eyeFOV[VRDisplayState::NumEyes];
-  Point3D_POD eyeTranslation[VRDisplayState::NumEyes];
+  float eyeTransform[VRDisplayState::NumEyes][16];
   IntSize_POD eyeResolution;
   float nativeFramebufferScaleFactor;
   bool suppressFrames;

--- a/gfx/vr/gfxVR.cpp
+++ b/gfx/vr/gfxVR.cpp
@@ -72,9 +72,17 @@ const IntSize VRDisplayInfo::SuggestedEyeResolution() const {
 }
 
 const Point3D VRDisplayInfo::GetEyeTranslation(uint32_t whichEye) const {
-  return Point3D(mDisplayState.eyeTranslation[whichEye].x,
-                 mDisplayState.eyeTranslation[whichEye].y,
-                 mDisplayState.eyeTranslation[whichEye].z);
+  return Point3D(mDisplayState.eyeTransform[whichEye][12],
+                 mDisplayState.eyeTransform[whichEye][13],
+                 mDisplayState.eyeTransform[whichEye][14]);
+}
+
+const Matrix4x4Double VRDisplayInfo::GetEyeTransform(uint32_t whichEye) const {
+  Matrix4x4Double m;
+  for (int i = 0; i < 16; ++i) {
+    m.components[i] = static_cast<double>(mDisplayState.eyeTransform[whichEye][i]);
+  }
+  return m;
 }
 
 const Size VRDisplayInfo::GetStageSize() const {

--- a/gfx/vr/gfxVR.h
+++ b/gfx/vr/gfxVR.h
@@ -65,6 +65,7 @@ struct VRDisplayInfo {
 
   const IntSize SuggestedEyeResolution() const;
   const Point3D GetEyeTranslation(uint32_t whichEye) const;
+  const Matrix4x4Double GetEyeTransform(uint32_t whichEye) const;
   const VRFieldOfView& GetEyeFOV(uint32_t whichEye) const {
     return mDisplayState.eyeFOV[whichEye];
   }

--- a/mobile/android/geckoview/src/main/java/org/mozilla/geckoview/GeckoRuntimeSettings.java
+++ b/mobile/android/geckoview/src/main/java/org/mozilla/geckoview/GeckoRuntimeSettings.java
@@ -500,7 +500,7 @@ public final class GeckoRuntimeSettings extends RuntimeSettings {
   /* package */ final Pref<Boolean> mInputAutoZoom = new Pref<>("formhelper.autozoom", true);
   /* package */ final Pref<Boolean> mDoubleTapZooming =
       new Pref<>("apz.allow_double_tap_zooming", true);
-  /* package */ final Pref<Integer> mGlMsaaLevel = new Pref<>("gl.msaa-level", 0);
+  /* package */ final Pref<Integer> mGlMsaaLevel = new Pref<>("webgl.msaa-samples", 4);
   /* package */ final Pref<Boolean> mTelemetryEnabled =
       new Pref<>("toolkit.telemetry.geckoview.streaming", false);
   /* package */ final Pref<String> mGeckoViewLogLevel = new Pref<>("geckoview.logging", "Debug");

--- a/modules/libpref/init/StaticPrefList.yaml
+++ b/modules/libpref/init/StaticPrefList.yaml
@@ -8140,7 +8140,11 @@
 - name: media.cubeb.sandbox_v2
   type: bool
   mirror: always
-#if defined(XP_MACOSX)
+#if defined(XP_LINUX) && !defined(MOZ_WIDGET_ANDROID)
+  value: true
+#elif defined(XP_WIN) && !defined(_ARM64_)
+  value: true
+#elif defined(XP_MACOSX)
   value: true
 #else
   value: false

--- a/toolkit/moz.configure
+++ b/toolkit/moz.configure
@@ -2198,7 +2198,6 @@ set_define("MOZ_HAS_REMOTE", has_remote)
 def wasm_sandboxing_libraries():
     return (
         "graphite",
-        "ogg",
         "hunspell",
         "expat",
         "woff2",


### PR DESCRIPTION
This fixes build of qcms due to missing std::arch::is_aarch64_feature_detected, required to detect neon support.