### PR TITLE
Fix leak in _cairo_dwrite_font_face_create_for_toy()

### DIFF
--- a/gfx/cairo/cairo/src/win32/cairo-dwrite-font.cpp
+++ b/gfx/cairo/cairo/src/win32/cairo-dwrite-font.cpp
@@ -243,7 +243,7 @@ _cairo_dwrite_font_face_create_for_toy (cairo_toy_font_face_t   *toy_face,
     MultiByteToWideChar(CP_UTF8, 0, toy_face->family, -1, face_name, face_name_len);
 
     IDWriteFontFamily *family = DWriteFactory::FindSystemFontFamily(face_name);
-    delete face_name;
+    delete[] face_name;
     if (!family) {
 	*font_face = (cairo_font_face_t*)&_cairo_font_face_nil;
 	return CAIRO_STATUS_FONT_TYPE_MISMATCH;


### PR DESCRIPTION
Use delete[] to free array instead of plain delete.

This fix is taken from Cairo:
https://gitlab.freedesktop.org/cairo/cairo/-/merge_requests/354