### PR TITLE
Bug 1894414 : Remove broken css rule

### DIFF
--- a/browser/themes/shared/customizableui/panelUI-shared.css
+++ b/browser/themes/shared/customizableui/panelUI-shared.css
@@ -178,9 +178,11 @@ panelview {
     one view to another runs, which would otherwise happen if the new view has
     more height than the old one because that would mean that during the
     animation the height of the multiview will be too short for the new view. */
+  /* commented out based on bug report  https://bugzilla.mozilla.org/show_bug.cgi?id=1894414 :
+  
   &[transitioning] > .panel-viewcontainer > .panel-viewstack > panelview > .panel-subview-body {
     overflow-y: hidden;
-  }
+  } */
 }
 
 .panel-subview-body {


### PR DESCRIPTION
[Bug 1859349](https://bugzilla.mozilla.org/show_bug.cgi?id=1859349)'s refactoring of panelUI-shared.css turned this rule:

panelmultiview[transitioning] > .panel-viewcontainer > .panel-viewstack > panelview > .panel-subview-body {
  overflow-y: hidden;
}
Into:

panelview {
  &[transitioning] > .panel-viewcontainer > .panel-viewstack > panelview > .panel-subview-body {
    overflow-y: hidden;
  }
}
Which is subtly incorrect. The transitioning attribute is only added to panelmultiview, not panelview, so the selector never matches anything.

To reduce confusion, this broken rule should be removed.
 
Changes made in line 176 - 186